### PR TITLE
Add date range filter and server-side column sorting to deficiency list

### DIFF
--- a/app/api/deficiencies/route.ts
+++ b/app/api/deficiencies/route.ts
@@ -32,6 +32,23 @@ export async function GET(req: NextRequest) {
     params.push(trade);
   }
 
+  const date_from = searchParams.get("date_from");
+  if (date_from) {
+    conditions.push("created_at >= ?");
+    params.push(date_from);
+  }
+
+  const date_to = searchParams.get("date_to");
+  if (date_to) {
+    conditions.push("created_at < ?");
+    params.push(date_to + "T23:59:59.999Z");
+  }
+
+  const ALLOWED_SORT_COLS = ["id", "title", "severity", "status", "category", "location", "trade", "created_at"];
+  const sortByRaw = searchParams.get("sort_by") ?? "created_at";
+  const sort_by = ALLOWED_SORT_COLS.includes(sortByRaw) ? sortByRaw : "created_at";
+  const sort_dir = searchParams.get("sort_dir") === "asc" ? "ASC" : "DESC";
+
   const page = parseInt(searchParams.get("page") ?? "1", 10);
   const limit = Math.min(parseInt(searchParams.get("limit") ?? "50", 10), 200);
   const offset = (page - 1) * limit;
@@ -39,7 +56,7 @@ export async function GET(req: NextRequest) {
   const where = conditions.join(" AND ");
   const rows = db
     .prepare(
-      `SELECT * FROM deficiencies WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`
+      `SELECT * FROM deficiencies WHERE ${where} ORDER BY ${sort_by} ${sort_dir} LIMIT ? OFFSET ?`
     )
     .all(...params, limit, offset);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,6 +28,10 @@ export default function Home() {
   const [filterSeverity, setFilterSeverity] = useState("");
   const [filterStatus, setFilterStatus] = useState("");
   const [filterTrade, setFilterTrade] = useState("");
+  const [filterDateFrom, setFilterDateFrom] = useState("");
+  const [filterDateTo, setFilterDateTo] = useState("");
+  const [sortBy, setSortBy] = useState("created_at");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
 
   const [showModal, setShowModal] = useState(false);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
@@ -51,6 +55,10 @@ export default function Home() {
     if (filterSeverity) params.set("severity", filterSeverity);
     if (filterStatus) params.set("status", filterStatus);
     if (filterTrade) params.set("trade", filterTrade);
+    if (filterDateFrom) params.set("date_from", filterDateFrom);
+    if (filterDateTo) params.set("date_to", filterDateTo);
+    params.set("sort_by", sortBy);
+    params.set("sort_dir", sortDir);
 
     fetch(`/api/deficiencies?${params}`)
       .then((r) => r.json())
@@ -59,7 +67,7 @@ export default function Home() {
     fetch(`/api/deficiencies/stats?project_id=${selectedProject.id}`)
       .then((r) => r.json())
       .then((j) => { if (j.success) setStats(j.data); });
-  }, [selectedProject, filterSeverity, filterStatus, filterTrade]);
+  }, [selectedProject, filterSeverity, filterStatus, filterTrade, filterDateFrom, filterDateTo, sortBy, sortDir]);
 
   useEffect(() => { loadData(); }, [loadData]);
 
@@ -90,6 +98,26 @@ export default function Home() {
   }
 
   const trades = [...new Set(deficiencies.map((d) => d.trade).filter(Boolean))].sort();
+
+  const SORT_COLS: { label: string; col: string }[] = [
+    { label: "ID", col: "id" },
+    { label: "Title", col: "title" },
+    { label: "Severity", col: "severity" },
+    { label: "Status", col: "status" },
+    { label: "Category", col: "category" },
+    { label: "Location", col: "location" },
+    { label: "Trade", col: "trade" },
+    { label: "Date", col: "created_at" },
+  ];
+
+  function handleSort(col: string) {
+    if (sortBy === col) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(col);
+      setSortDir("asc");
+    }
+  }
 
   return (
     <div className="min-h-screen bg-stone-50">
@@ -216,8 +244,23 @@ export default function Home() {
             <option value="">All Trades</option>
             {trades.map((t) => <option key={t}>{t}</option>)}
           </select>
-          {(filterSeverity || filterStatus || filterTrade) && (
-            <button onClick={() => { setFilterSeverity(""); setFilterStatus(""); setFilterTrade(""); }}
+          <input
+            type="date"
+            value={filterDateFrom}
+            onChange={(e) => setFilterDateFrom(e.target.value)}
+            title="Created after"
+            className="border border-stone-300 rounded-lg px-3 py-1.5 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-stone-400 text-stone-600"
+          />
+          <span className="text-stone-400 text-xs">to</span>
+          <input
+            type="date"
+            value={filterDateTo}
+            onChange={(e) => setFilterDateTo(e.target.value)}
+            title="Created before"
+            className="border border-stone-300 rounded-lg px-3 py-1.5 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-stone-400 text-stone-600"
+          />
+          {(filterSeverity || filterStatus || filterTrade || filterDateFrom || filterDateTo) && (
+            <button onClick={() => { setFilterSeverity(""); setFilterStatus(""); setFilterTrade(""); setFilterDateFrom(""); setFilterDateTo(""); }}
               className="text-xs text-stone-400 hover:text-red-600 underline underline-offset-2">
               Clear filters
             </button>
@@ -232,7 +275,7 @@ export default function Home() {
               <div className="text-4xl mb-3">📋</div>
               <div className="font-medium text-stone-600">No deficiencies found</div>
               <div className="text-sm mt-1">
-                {filterSeverity || filterStatus || filterTrade
+                {filterSeverity || filterStatus || filterTrade || filterDateFrom || filterDateTo
                   ? "Try adjusting your filters"
                   : "Click \"+ New Deficiency\" to log the first one"}
               </div>
@@ -242,9 +285,16 @@ export default function Home() {
               <table className="w-full text-sm">
                 <thead>
                   <tr className="bg-stone-50 border-b border-stone-200">
-                    {["ID", "Title", "Severity", "Status", "Category", "Location", "Trade", "Date"].map((h) => (
-                      <th key={h} className="px-4 py-3 text-left text-[11px] font-semibold text-stone-400 uppercase tracking-wider whitespace-nowrap">
-                        {h}
+                    {SORT_COLS.map(({ label, col }) => (
+                      <th
+                        key={col}
+                        onClick={() => handleSort(col)}
+                        className="px-4 py-3 text-left text-[11px] font-semibold text-stone-400 uppercase tracking-wider whitespace-nowrap cursor-pointer select-none hover:text-stone-600 transition-colors"
+                      >
+                        {label}
+                        <span className="ml-1 text-[10px]">
+                          {sortBy === col ? (sortDir === "asc" ? "↑" : "↓") : "↕"}
+                        </span>
                       </th>
                     ))}
                   </tr>


### PR DESCRIPTION
Closes Phase 1 PRD gaps (FR-04, FR-06, FR-12):
- API: adds date_from / date_to query params (inclusive range on created_at)
- API: adds sort_by / sort_dir params with whitelist guard against SQL injection; replaces hardcoded ORDER BY created_at DESC
- Frontend: two date inputs in filter bar (Created After / Created Before)
- Frontend: all 8 table column headers are now clickable sort toggles with ↑ / ↓ / ↕ indicators; sort state persists across pagination

https://claude.ai/code/session_018e98oGa3oG34Bwq9m87veo