### PR TITLE
Add Phase 2: ChatGPT integration via MCP server and OpenAI Apps SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,25 @@
 
 A construction site inspection tracker built as a two-phase prototype demonstrating how SaaS products connect to AI conversational platforms.
 
-**Phase 1 (this branch):** Standalone Next.js web app with a clean REST API backed by SQLite.
-**Phase 2 (planned):** ChatGPT integration via OpenAI Apps SDK / MCP server, calling the same REST API.
+**Phase 1:** Standalone Next.js web app with a REST API backed by SQLite.
+**Phase 2:** ChatGPT integration via OpenAI Apps SDK + MCP server, calling the same REST API.
 
 The analogy is OpenTable — users can log inspections via the web app *or* through ChatGPT. Same database, two interfaces.
 
 ---
 
-## Quick Start
+## Architecture
+
+```
+[React Frontend]  →  [REST API]  →  [SQLite DB]
+[MCP Server]      →  [REST API]  →  [SQLite DB]
+```
+
+The MCP server is a thin wrapper — all business logic lives in the REST API. A deficiency created via ChatGPT appears immediately in the web app, and vice versa.
+
+---
+
+## Quick Start — Phase 1 (Web App)
 
 ```bash
 npm install
@@ -17,13 +28,51 @@ npm run setup   # creates SQLite DB + seeds 3 projects, 8 deficiencies
 npm run dev     # http://localhost:3000
 ```
 
-No Docker, no external services, no API keys required for Phase 1.
+No Docker, no external services, no API keys required.
 
 ---
 
-## What's in Phase 1
+## Quick Start — Phase 2 (ChatGPT Integration)
 
-### Web App
+Requires the web app running on port 3000 and ngrok installed.
+
+```bash
+# Terminal 1 — Next.js REST API
+npm run dev
+
+# Terminal 2 — MCP server
+npm run mcp     # http://localhost:8787
+
+# Terminal 3 — expose MCP server publicly
+ngrok http 8787
+```
+
+### Register in ChatGPT
+
+1. Go to **chatgpt.com** → profile → **Settings → Apps**
+2. Click **Add app** → paste `<ngrok-url>/mcp`
+3. Complete the OAuth flow (auto-approves in dev)
+4. In a new chat, click **"+"** near the input to add SiteCheck to the conversation
+
+### Test prompts
+
+| Prompt | Widget rendered |
+|---|---|
+| "Show me my SiteCheck projects" | Project dashboard |
+| "Show deficiencies for Maple Street" | Deficiency table |
+| "Show only Critical deficiencies for Maple Street" | Deficiency table (filtered) |
+| "Show stats for Maple Street" | Stats dashboard |
+| "Log a cracked beam at Grid B4 on Maple Street" | Deficiency form (pre-filled) |
+| "Change the severity of DEF-001" | Severity picker |
+| "Attach a photo to DEF-001" | Photo upload |
+| "Generate a report for Maple Street" | Report download |
+| "Mark DEF-001 as resolved" | Text only (no widget) |
+
+> **Tip:** ngrok free tunnels expire after a few hours. When the URL changes, remove and re-add the app in ChatGPT settings. A free static domain is available at dashboard.ngrok.com.
+
+---
+
+## What's in the Web App
 
 - **Project selector** — switch between projects from the header
 - **Summary dashboard** — total count, counts by severity (clickable to filter), counts by status
@@ -33,16 +82,9 @@ No Docker, no external services, no API keys required for Phase 1.
 - **Inline status cycling** — click any status badge to advance it (Open → In Progress → Resolved → Closed)
 - **Report generation** — generates a PDF inspection report, available for immediate download
 
-### Severity colors (consistent everywhere)
+---
 
-| Severity | Color |
-|---|---|
-| Critical | Red |
-| Major | Orange |
-| Minor | Yellow |
-| Observation | Blue |
-
-### REST API
+## REST API
 
 All responses use a consistent envelope:
 ```json
@@ -56,11 +98,11 @@ All responses use a consistent envelope:
 | `/api/deficiencies` | POST | Create a deficiency |
 | `/api/deficiencies/[id]` | GET | Get a single deficiency |
 | `/api/deficiencies/[id]` | PATCH | Update fields (severity, status, title, etc.) |
-| `/api/deficiencies/[id]/photos` | POST | Upload a photo (multipart/form-data), attach to deficiency |
+| `/api/deficiencies/[id]/photos` | POST | Upload a photo (multipart/form-data) |
 | `/api/deficiencies/stats` | GET | Counts grouped by severity and status for a `project_id` |
-| `/api/reports/generate` | POST | Generate a PDF report for a `project_id`, returns download URL |
+| `/api/reports/generate` | POST | Generate a PDF report, returns download URL |
 
-#### Enums
+### Enums
 
 | Field | Values |
 |---|---|
@@ -70,15 +112,21 @@ All responses use a consistent envelope:
 
 ---
 
-## Tech Stack
+## MCP Tools
 
-| Layer | Technology |
-|---|---|
-| Framework | Next.js 16 (App Router) |
-| Styling | Tailwind CSS v4 |
-| Database | SQLite via `better-sqlite3` |
-| PDF generation | `pdfkit` |
-| Language | TypeScript |
+The MCP server exposes these tools to ChatGPT:
+
+| Tool | Widget | Description |
+|---|---|---|
+| `set_project` | — | Silent project lookup (resolves name → ID) |
+| `show_projects` | project-dashboard | Browse all projects |
+| `log_deficiency` | deficiency-form | Pre-filled form to log a new deficiency |
+| `get_deficiency_list` | deficiency-table | List/filter deficiencies |
+| `get_summary_stats` | stats-dashboard | Counts by severity and status |
+| `set_severity` | severity-picker | Pick/confirm severity for a deficiency |
+| `update_status` | — | Directly patch status (no UI needed) |
+| `upload_photo` | photo-upload | Attach a photo to a deficiency |
+| `generate_report` | report-download | Generate PDF + download link |
 
 ---
 
@@ -106,11 +154,35 @@ All responses use a consistent envelope:
 ├── lib/
 │   ├── api.ts                    # Response helpers + enum constants
 │   └── db.ts                     # SQLite singleton
+├── mcp/
+│   ├── server.js                 # MCP server (thin wrapper over REST API)
+│   └── widgets/                  # Embedded UI HTML files
+│       ├── project-dashboard.html
+│       ├── deficiency-form.html
+│       ├── deficiency-table.html
+│       ├── severity-picker.html
+│       ├── photo-upload.html
+│       ├── stats-dashboard.html
+│       └── report-download.html
+├── middleware.ts                 # CORS headers for API routes
 ├── public/
-│   ├── uploads/                  # Photo uploads stored here
-│   └── reports/                  # Generated PDFs stored here
-└── types/index.ts                # Shared TypeScript types
+│   ├── uploads/                  # Photo uploads
+│   └── reports/                  # Generated PDFs
+└── types/index.ts
 ```
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | Next.js 16 (App Router) |
+| Styling | Tailwind CSS v4 |
+| Database | SQLite via `better-sqlite3` |
+| PDF generation | `pdfkit` |
+| MCP server | `@modelcontextprotocol/sdk` + `@modelcontextprotocol/ext-apps` |
+| Language | TypeScript |
 
 ---
 
@@ -134,9 +206,9 @@ All responses use a consistent envelope:
 | `project_id` | TEXT | Foreign key → projects |
 | `title` | TEXT | |
 | `description` | TEXT | |
-| `category` | TEXT | Enum — see above |
-| `severity` | TEXT | Enum — see above |
-| `status` | TEXT | Enum — see above, default `Open` |
+| `category` | TEXT | Enum |
+| `severity` | TEXT | Enum |
+| `status` | TEXT | Enum, default `Open` |
 | `location` | TEXT | Grid ref or description |
 | `trade` | TEXT | Responsible trade |
 | `photo_paths` | TEXT | JSON array of `/uploads/...` paths |
@@ -145,26 +217,12 @@ All responses use a consistent envelope:
 
 ---
 
-## API Design Notes (for Phase 2 / MCP integration)
-
-The REST API is intentionally designed for external consumers, not just the frontend:
-
-- **Consistent envelope** — every response has `success`, `data`, `error`
-- **Enum validation** — invalid values return a `400` with a clear message listing accepted values
-- **Filter parameters** on list endpoints — the MCP server can query by severity, status, trade without fetching everything
-- **Pagination** — `?page=N&limit=N` on `/api/deficiencies` (max 200 per page)
-- **Idempotency-friendly** — PATCH accepts partial updates; creating duplicate deficiencies generates a new sequential ID
-
-In Phase 2, an MCP server will wrap these endpoints as ChatGPT tools — each tool handler is a thin HTTP call to this API with no duplicated business logic.
-
----
-
 ## Seed Data
 
 `npm run setup` seeds:
 
-- **Oakwood Tower** — 22-story mixed-use residential tower, Denver CO (4 deficiencies)
-- **Riverside Industrial Park** — warehouse/logistics facility, Aurora CO (2 deficiencies)
-- **Maple Street Renovation** — historic seismic retrofit, Boulder CO (2 deficiencies)
+- **Maple Street Renovation** — historic seismic retrofit, Boulder CO
+- **Oakwood Tower** — 22-story mixed-use tower, Denver CO
+- **Riverside Industrial Park** — warehouse/logistics facility, Aurora CO
 
 Deficiencies span all severity levels and statuses so the dashboard and filters are populated immediately.

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,9 +1,17 @@
+import { NextRequest } from "next/server";
 import { db } from "@/lib/db";
 import { ok } from "@/lib/api";
 
-export async function GET() {
-  const projects = db
-    .prepare("SELECT * FROM projects ORDER BY name ASC")
-    .all();
+export async function GET(req: NextRequest) {
+  const q = req.nextUrl.searchParams.get("q")?.trim();
+
+  const projects = q
+    ? db
+        .prepare(
+          "SELECT * FROM projects WHERE LOWER(name) LIKE LOWER(?) OR LOWER(location) LIKE LOWER(?) ORDER BY name ASC"
+        )
+        .all(`%${q}%`, `%${q}%`)
+    : db.prepare("SELECT * FROM projects ORDER BY name ASC").all();
+
   return ok(projects);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #fafaf9;
-  --foreground: #1c1917;
+  --background: #0c0a09;
+  --foreground: #f5f5f4;
 }
 
 body {
@@ -12,5 +12,5 @@ body {
 }
 
 ::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: #f5f5f4; }
-::-webkit-scrollbar-thumb { background: #a8a29e; border-radius: 3px; }
+::-webkit-scrollbar-track { background: #1c1917; }
+::-webkit-scrollbar-thumb { background: #57534e; border-radius: 3px; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,9 +14,9 @@ function statusDotColor(status: string) {
     "Open": "bg-red-500",
     "In Progress": "bg-amber-500",
     "Resolved": "bg-green-500",
-    "Closed": "bg-stone-400",
+    "Closed": "bg-stone-500",
   };
-  return m[status] ?? "bg-stone-400";
+  return m[status] ?? "bg-stone-500";
 }
 
 export default function Home() {
@@ -120,7 +120,7 @@ export default function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-stone-50">
+    <div className="min-h-screen bg-stone-950">
       {/* Header */}
       <header className="bg-stone-900 border-b border-stone-700">
         <div className="max-w-7xl mx-auto px-6 flex items-center justify-between h-14">
@@ -149,7 +149,7 @@ export default function Home() {
           <div className="flex items-center gap-2">
             {reportUrl && (
               <a href={reportUrl} download
-                className="px-3 py-1.5 text-xs font-semibold rounded-lg bg-green-600 text-white hover:bg-green-500 transition-colors">
+                className="px-3 py-1.5 text-xs font-semibold rounded-lg bg-green-700 text-white hover:bg-green-600 transition-colors">
                 ↓ Download Report
               </a>
             )}
@@ -175,7 +175,7 @@ export default function Home() {
         {/* Project title */}
         {selectedProject && (
           <div>
-            <h1 className="text-2xl font-bold text-stone-900">{selectedProject.name}</h1>
+            <h1 className="text-2xl font-bold text-stone-100">{selectedProject.name}</h1>
             <p className="text-stone-500 text-sm">{selectedProject.location}</p>
           </div>
         )}
@@ -185,19 +185,19 @@ export default function Home() {
           <div className="space-y-3">
             {/* Total + severity cards */}
             <div className="grid grid-cols-5 gap-3">
-              <div className="bg-white border border-stone-200 rounded-xl p-4 flex flex-col shadow-sm">
-                <span className="text-3xl font-black text-stone-900">{stats.total}</span>
-                <span className="text-[10px] text-stone-400 font-semibold uppercase tracking-widest mt-1">Total</span>
+              <div className="bg-stone-800 border border-stone-700 rounded-xl p-4 flex flex-col">
+                <span className="text-3xl font-black text-stone-100">{stats.total}</span>
+                <span className="text-[10px] text-stone-500 font-semibold uppercase tracking-widest mt-1">Total</span>
               </div>
               {SEVERITIES.map((sev) => (
                 <button
                   key={sev}
                   onClick={() => setFilterSeverity(filterSeverity === sev ? "" : sev)}
-                  className={`bg-white border rounded-xl p-4 flex flex-col text-left transition-all hover:shadow-md shadow-sm ${
-                    filterSeverity === sev ? "border-stone-700 ring-2 ring-stone-700" : "border-stone-200"
+                  className={`bg-stone-800 border rounded-xl p-4 flex flex-col text-left transition-all hover:border-stone-500 ${
+                    filterSeverity === sev ? "border-orange-500 ring-2 ring-orange-500" : "border-stone-700"
                   }`}
                 >
-                  <span className="text-2xl font-black text-stone-900">{stats.by_severity[sev] ?? 0}</span>
+                  <span className="text-2xl font-black text-stone-100">{stats.by_severity[sev] ?? 0}</span>
                   <span className={`mt-1.5 inline-block px-1.5 py-0.5 rounded text-[10px] font-bold ${SEVERITY_STYLES[sev]}`}>
                     {sev}
                   </span>
@@ -211,15 +211,15 @@ export default function Home() {
                 <button
                   key={st}
                   onClick={() => setFilterStatus(filterStatus === st ? "" : st)}
-                  className={`bg-white border rounded-xl px-4 py-3 flex items-center justify-between shadow-sm transition-all hover:shadow-md ${
-                    filterStatus === st ? "border-stone-700 ring-2 ring-stone-700" : "border-stone-200"
+                  className={`bg-stone-800 border rounded-xl px-4 py-3 flex items-center justify-between transition-all hover:border-stone-500 ${
+                    filterStatus === st ? "border-orange-500 ring-2 ring-orange-500" : "border-stone-700"
                   }`}
                 >
-                  <div className="flex items-center gap-2 text-sm text-stone-700">
+                  <div className="flex items-center gap-2 text-sm text-stone-300">
                     <span className={`w-2 h-2 rounded-full ${statusDotColor(st)}`} />
                     {st}
                   </div>
-                  <span className="text-lg font-bold text-stone-900">{stats.by_status[st] ?? 0}</span>
+                  <span className="text-lg font-bold text-stone-100">{stats.by_status[st] ?? 0}</span>
                 </button>
               ))}
             </div>
@@ -230,17 +230,17 @@ export default function Home() {
         <div className="flex flex-wrap items-center gap-3">
           <span className="text-sm font-medium text-stone-500">Filter:</span>
           <select value={filterSeverity} onChange={(e) => setFilterSeverity(e.target.value)}
-            className="border border-stone-300 rounded-lg px-3 py-1.5 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-stone-400">
+            className="border border-stone-700 rounded-lg px-3 py-1.5 text-sm bg-stone-800 text-stone-200 focus:outline-none focus:ring-2 focus:ring-stone-500">
             <option value="">All Severities</option>
             {SEVERITIES.map((s) => <option key={s}>{s}</option>)}
           </select>
           <select value={filterStatus} onChange={(e) => setFilterStatus(e.target.value)}
-            className="border border-stone-300 rounded-lg px-3 py-1.5 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-stone-400">
+            className="border border-stone-700 rounded-lg px-3 py-1.5 text-sm bg-stone-800 text-stone-200 focus:outline-none focus:ring-2 focus:ring-stone-500">
             <option value="">All Statuses</option>
             {STATUSES.map((s) => <option key={s}>{s}</option>)}
           </select>
           <select value={filterTrade} onChange={(e) => setFilterTrade(e.target.value)}
-            className="border border-stone-300 rounded-lg px-3 py-1.5 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-stone-400">
+            className="border border-stone-700 rounded-lg px-3 py-1.5 text-sm bg-stone-800 text-stone-200 focus:outline-none focus:ring-2 focus:ring-stone-500">
             <option value="">All Trades</option>
             {trades.map((t) => <option key={t}>{t}</option>)}
           </select>
@@ -265,15 +265,15 @@ export default function Home() {
               Clear filters
             </button>
           )}
-          <span className="ml-auto text-sm text-stone-400">{deficiencies.length} result{deficiencies.length !== 1 ? "s" : ""}</span>
+          <span className="ml-auto text-sm text-stone-500">{deficiencies.length} result{deficiencies.length !== 1 ? "s" : ""}</span>
         </div>
 
         {/* Deficiency table */}
-        <div className="bg-white border border-stone-200 rounded-xl overflow-hidden shadow-sm">
+        <div className="bg-stone-900 border border-stone-700 rounded-xl overflow-hidden">
           {deficiencies.length === 0 ? (
-            <div className="text-center py-16 text-stone-400">
+            <div className="text-center py-16 text-stone-500">
               <div className="text-4xl mb-3">📋</div>
-              <div className="font-medium text-stone-600">No deficiencies found</div>
+              <div className="font-medium text-stone-400">No deficiencies found</div>
               <div className="text-sm mt-1">
                 {filterSeverity || filterStatus || filterTrade || filterDateFrom || filterDateTo
                   ? "Try adjusting your filters"
@@ -299,22 +299,22 @@ export default function Home() {
                     ))}
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-stone-100">
+                <tbody className="divide-y divide-stone-800">
                   {deficiencies.map((def) => {
                     const photos: string[] = JSON.parse(def.photo_paths);
                     return (
-                      <tr key={def.id} className="hover:bg-stone-50/80 transition-colors">
-                        <td className="px-4 py-3 font-mono text-[11px] text-stone-400 whitespace-nowrap">{def.id}</td>
+                      <tr key={def.id} className="hover:bg-stone-800/60 transition-colors">
+                        <td className="px-4 py-3 font-mono text-[11px] text-stone-500 whitespace-nowrap">{def.id}</td>
                         <td className="px-4 py-3 max-w-[260px]">
-                          <div className="font-semibold text-stone-900 truncate">{def.title}</div>
+                          <div className="font-semibold text-stone-100 truncate">{def.title}</div>
                           {def.description && (
-                            <div className="text-xs text-stone-400 mt-0.5 truncate">{def.description}</div>
+                            <div className="text-xs text-stone-500 mt-0.5 truncate">{def.description}</div>
                           )}
                           {photos.length > 0 && (
                             <div className="flex gap-2 mt-1">
                               {photos.map((p, i) => (
                                 <a key={i} href={p} target="_blank" rel="noreferrer"
-                                  className="text-[10px] text-blue-500 hover:underline">📷 Photo {i + 1}</a>
+                                  className="text-[10px] text-blue-400 hover:underline">📷 Photo {i + 1}</a>
                               ))}
                             </div>
                           )}
@@ -327,10 +327,10 @@ export default function Home() {
                             onClick={() => cycleStatus(def)}
                           />
                         </td>
-                        <td className="px-4 py-3 text-stone-600 whitespace-nowrap">{def.category}</td>
-                        <td className="px-4 py-3 text-stone-600 max-w-[140px] truncate">{def.location || "—"}</td>
-                        <td className="px-4 py-3 text-stone-600 whitespace-nowrap">{def.trade || "—"}</td>
-                        <td className="px-4 py-3 text-stone-400 text-[11px] whitespace-nowrap">{fmt(def.created_at)}</td>
+                        <td className="px-4 py-3 text-stone-400 whitespace-nowrap">{def.category}</td>
+                        <td className="px-4 py-3 text-stone-400 max-w-[140px] truncate">{def.location || "—"}</td>
+                        <td className="px-4 py-3 text-stone-400 whitespace-nowrap">{def.trade || "—"}</td>
+                        <td className="px-4 py-3 text-stone-500 text-[11px] whitespace-nowrap">{fmt(def.created_at)}</td>
                       </tr>
                     );
                   })}

--- a/components/NewDeficiencyModal.tsx
+++ b/components/NewDeficiencyModal.tsx
@@ -60,77 +60,77 @@ export function NewDeficiencyModal({ projectId, onClose, onCreated }: Props) {
   }
 
   const severityColors: Record<string, string> = {
-    Critical: "border-red-500 bg-red-50",
-    Major: "border-orange-500 bg-orange-50",
-    Minor: "border-yellow-400 bg-yellow-50",
-    Observation: "border-blue-500 bg-blue-50",
+    Critical: "border-red-500 bg-red-950 text-red-300",
+    Major: "border-orange-500 bg-orange-950 text-orange-300",
+    Minor: "border-yellow-400 bg-yellow-950 text-yellow-300",
+    Observation: "border-blue-500 bg-blue-950 text-blue-300",
   };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+      <div className="bg-stone-900 rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-stone-200 bg-stone-900 rounded-t-xl">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-stone-700 bg-stone-800 rounded-t-xl">
           <h2 className="text-lg font-bold text-white">New Deficiency</h2>
           <button onClick={onClose} className="text-stone-400 hover:text-white text-2xl leading-none">×</button>
         </div>
 
         <form onSubmit={handleSubmit} className="p-6 space-y-5">
           {error && (
-            <div className="bg-red-50 border border-red-300 text-red-700 rounded-lg px-4 py-2 text-sm">{error}</div>
+            <div className="bg-red-950 border border-red-800 text-red-400 rounded-lg px-4 py-2 text-sm">{error}</div>
           )}
 
           {/* Title */}
           <div>
-            <label className="block text-sm font-semibold text-stone-700 mb-1">Title *</label>
+            <label className="block text-sm font-semibold text-stone-300 mb-1">Title *</label>
             <input
               type="text"
               value={form.title}
               onChange={(e) => set("title", e.target.value)}
               placeholder="Brief description of the deficiency"
-              className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500"
+              className="w-full border border-stone-700 rounded-lg px-3 py-2 text-sm bg-stone-800 text-stone-100 placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
             />
           </div>
 
           {/* Category + Trade */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-semibold text-stone-700 mb-1">Category</label>
+              <label className="block text-sm font-semibold text-stone-300 mb-1">Category</label>
               <select
                 value={form.category}
                 onChange={(e) => set("category", e.target.value)}
-                className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500"
+                className="w-full border border-stone-700 rounded-lg px-3 py-2 text-sm bg-stone-800 text-stone-100 placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
               >
                 {CATEGORIES.map((c) => <option key={c}>{c}</option>)}
               </select>
             </div>
             <div>
-              <label className="block text-sm font-semibold text-stone-700 mb-1">Trade</label>
+              <label className="block text-sm font-semibold text-stone-300 mb-1">Trade</label>
               <input
                 type="text"
                 value={form.trade}
                 onChange={(e) => set("trade", e.target.value)}
                 placeholder="e.g. Electrical, Concrete"
-                className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500"
+                className="w-full border border-stone-700 rounded-lg px-3 py-2 text-sm bg-stone-800 text-stone-100 placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
               />
             </div>
           </div>
 
           {/* Location */}
           <div>
-            <label className="block text-sm font-semibold text-stone-700 mb-1">Location</label>
+            <label className="block text-sm font-semibold text-stone-300 mb-1">Location</label>
             <input
               type="text"
               value={form.location}
               onChange={(e) => set("location", e.target.value)}
               placeholder="e.g. Grid B4, Floor 14, East Wall"
-              className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500"
+              className="w-full border border-stone-700 rounded-lg px-3 py-2 text-sm bg-stone-800 text-stone-100 placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
             />
           </div>
 
           {/* Severity picker */}
           <div>
-            <label className="block text-sm font-semibold text-stone-700 mb-2">Severity</label>
+            <label className="block text-sm font-semibold text-stone-300 mb-2">Severity</label>
             <div className="grid grid-cols-4 gap-2">
               {SEVERITIES.map((s) => (
                 <button
@@ -140,7 +140,7 @@ export function NewDeficiencyModal({ projectId, onClose, onCreated }: Props) {
                   className={`py-2 rounded-lg border-2 text-sm font-bold transition-all ${
                     form.severity === s
                       ? severityColors[s] + " ring-2 ring-offset-1 ring-stone-400"
-                      : "border-stone-200 bg-white text-stone-500 hover:border-stone-400"
+                      : "border-stone-700 bg-stone-800 text-stone-400 hover:border-stone-500"
                   }`}
                 >
                   {s}
@@ -151,7 +151,7 @@ export function NewDeficiencyModal({ projectId, onClose, onCreated }: Props) {
 
           {/* Status */}
           <div>
-            <label className="block text-sm font-semibold text-stone-700 mb-1">Initial Status</label>
+            <label className="block text-sm font-semibold text-stone-300 mb-1">Initial Status</label>
             <div className="flex gap-2 flex-wrap">
               {STATUSES.map((s) => (
                 <button
@@ -161,7 +161,7 @@ export function NewDeficiencyModal({ projectId, onClose, onCreated }: Props) {
                   className={`px-3 py-1 rounded-full text-xs font-semibold border transition-all ${
                     form.status === s
                       ? "bg-stone-800 text-white border-stone-800"
-                      : "bg-white text-stone-500 border-stone-300 hover:border-stone-500"
+                      : "bg-stone-800 text-stone-400 border-stone-600 hover:border-stone-400"
                   }`}
                 >
                   {s}
@@ -172,25 +172,25 @@ export function NewDeficiencyModal({ projectId, onClose, onCreated }: Props) {
 
           {/* Description */}
           <div>
-            <label className="block text-sm font-semibold text-stone-700 mb-1">Description</label>
+            <label className="block text-sm font-semibold text-stone-300 mb-1">Description</label>
             <textarea
               value={form.description}
               onChange={(e) => set("description", e.target.value)}
               rows={3}
               placeholder="Detailed observations, measurements, references to drawings..."
-              className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500 resize-none"
+              className="w-full border border-stone-700 rounded-lg px-3 py-2 text-sm bg-stone-800 text-stone-100 placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-orange-500 resize-none"
             />
           </div>
 
           {/* Photo upload */}
           <div>
-            <label className="block text-sm font-semibold text-stone-700 mb-1">Photo (optional)</label>
+            <label className="block text-sm font-semibold text-stone-300 mb-1">Photo (optional)</label>
             <div
-              className="border-2 border-dashed border-stone-300 rounded-lg p-4 text-center cursor-pointer hover:border-stone-500 transition-colors"
+              className="border-2 border-dashed border-stone-700 rounded-lg p-4 text-center cursor-pointer hover:border-stone-500 transition-colors"
               onClick={() => fileRef.current?.click()}
             >
               {photo ? (
-                <div className="flex items-center justify-center gap-2 text-sm text-stone-700">
+                <div className="flex items-center justify-center gap-2 text-sm text-stone-300">
                   <span className="text-green-600">✓</span>
                   <span className="font-medium">{photo.name}</span>
                   <button
@@ -220,7 +220,7 @@ export function NewDeficiencyModal({ projectId, onClose, onCreated }: Props) {
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-sm rounded-lg border border-stone-300 text-stone-600 hover:bg-stone-50"
+              className="px-4 py-2 text-sm rounded-lg border border-stone-700 text-stone-400 hover:bg-stone-800"
             >
               Cancel
             </button>

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS projects (
   name TEXT NOT NULL,
   location TEXT NOT NULL,
   description TEXT,
-  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
 );
 
 CREATE TABLE IF NOT EXISTS deficiencies (
@@ -17,6 +17,6 @@ CREATE TABLE IF NOT EXISTS deficiencies (
   location TEXT,
   trade TEXT,
   photo_paths TEXT NOT NULL DEFAULT '[]',
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
 );

--- a/db/setup.ts
+++ b/db/setup.ts
@@ -39,11 +39,13 @@ const projects = [
   },
 ];
 
+const now = new Date().toISOString();
+
 const insertProject = db.prepare(
-  "INSERT INTO projects (id, name, location, description) VALUES (?, ?, ?, ?)"
+  "INSERT INTO projects (id, name, location, description, created_at) VALUES (?, ?, ?, ?, ?)"
 );
 for (const p of projects) {
-  insertProject.run(p.id, p.name, p.location, p.description);
+  insertProject.run(p.id, p.name, p.location, p.description, now);
 }
 
 // Seed deficiencies
@@ -150,22 +152,15 @@ const deficiencies = [
 ];
 
 const insertDeficiency = db.prepare(`
-  INSERT INTO deficiencies (id, project_id, title, description, category, severity, status, location, trade, photo_paths)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO deficiencies (id, project_id, title, description, category, severity, status, location, trade, photo_paths, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 for (const d of deficiencies) {
   insertDeficiency.run(
-    d.id,
-    d.project_id,
-    d.title,
-    d.description,
-    d.category,
-    d.severity,
-    d.status,
-    d.location,
-    d.trade,
-    "[]"
+    d.id, d.project_id, d.title, d.description,
+    d.category, d.severity, d.status, d.location,
+    d.trade, "[]", now, now
   );
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -4,11 +4,19 @@ export function ok(data: unknown, status = 200) {
   return NextResponse.json({ success: true, data, error: null }, { status });
 }
 
-export function err(message: string, status = 400) {
+export function err(message: string, status = 400, code?: string) {
   return NextResponse.json(
-    { success: false, data: null, error: message },
+    { success: false, data: null, error: message, error_code: code ?? httpErrorCode(status) },
     { status }
   );
+}
+
+function httpErrorCode(status: number): string {
+  if (status === 404) return "NOT_FOUND";
+  if (status === 401) return "AUTH_REQUIRED";
+  if (status === 403) return "FORBIDDEN";
+  if (status === 429) return "RATE_LIMITED";
+  return "VALIDATION_ERROR";
 }
 
 export const CATEGORIES = [

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1,0 +1,799 @@
+/**
+ * SiteCheck AI — MCP Server
+ *
+ * Thin wrapper over the Phase 1 REST API. All business logic lives in
+ * the Next.js API routes at localhost:3000. This server only translates
+ * MCP tool calls into REST API requests.
+ *
+ * Transport: Streamable HTTP (stateless) on port 8787
+ * Register in ChatGPT: Settings → Apps → Developer Mode → <ngrok-url>/mcp
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { registerAppTool, registerAppResource, RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
+import { z } from "zod";
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const PORT = process.env.MCP_PORT ?? 8787;
+const API_BASE = process.env.API_BASE_URL ?? "http://localhost:3000";
+
+// ── Shared REST API helper ────────────────────────────────────────────────────
+// All tool handlers use this. Business logic stays in the REST API — this just
+// ferries requests and surfaces errors as MCP tool errors.
+async function api(path, options = {}) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { "Content-Type": "application/json" },
+    ...options,
+  });
+  const json = await res.json();
+  return { status: res.status, json };
+}
+
+function apiError(message) {
+  return {
+    isError: true,
+    content: [{ type: "text", text: message }],
+  };
+}
+
+// ── MCP Server ────────────────────────────────────────────────────────────────
+const server = new McpServer({
+  name: "sitecheck-ai",
+  version: "1.0.0",
+});
+
+// ── Enum constants (mirrors lib/api.ts — keep in sync) ───────────────────────
+const CATEGORIES = ["Structural", "Mechanical", "Electrical", "Plumbing", "Finish", "Safety", "Other"];
+const SEVERITIES = ["Critical", "Major", "Minor", "Observation"];
+const STATUSES   = ["Open", "In Progress", "Resolved", "Closed"];
+
+// ── Widget resource helper ────────────────────────────────────────────────────
+// Reads a widget HTML file from mcp/widgets/ and registers it as an App resource.
+// MIME type text/html;profile=mcp-app is set automatically by registerAppResource.
+// CSP connectDomains allows the widget to fetch from the REST API.
+function widgetResource(name, uri, filename) {
+  registerAppResource(
+    server,
+    name,
+    uri,
+    {},
+    async (resourceUri) => {
+      const filePath = path.join(__dirname, "widgets", filename);
+      const html = fs.readFileSync(filePath, "utf-8");
+      return {
+        contents: [{
+          uri: resourceUri.href,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: html,
+          _meta: {
+            ui: {
+              csp: {
+                connectDomains: [API_BASE],
+              },
+            },
+          },
+        }],
+      };
+    }
+  );
+}
+
+// ── Widget URI constants ──────────────────────────────────────────────────────
+const WIDGET_URIS = {
+  projectDashboard: "ui://sitecheck/project-dashboard.html",
+  deficiencyForm:   "ui://sitecheck/deficiency-form.html",
+  deficiencyTable:  "ui://sitecheck/deficiency-table.html",
+  severityPicker:   "ui://sitecheck/severity-picker.html",
+  photoUpload:      "ui://sitecheck/photo-upload.html",
+  statsDashboard:   "ui://sitecheck/stats-dashboard.html",
+  reportDownload:   "ui://sitecheck/report-download.html",
+};
+
+// ── Tool: set_project ─────────────────────────────────────────────────────────
+// Silent project lookup — no widget. Used internally by the model to resolve a
+// project name to an ID before calling other tools. Does NOT render UI so it
+// doesn't interrupt the flow when the user mentions a project by name.
+server.registerTool(
+  "set_project",
+  {
+    description: "Look up available SiteCheck projects and their IDs. Call this silently to resolve a project name before calling other tools. Do NOT call this when the user asks to 'show' or 'browse' projects — use show_projects for that.",
+    annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+  },
+  async () => {
+    let status, json;
+    try {
+      ({ status, json } = await api("/api/projects"));
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!json.success) {
+      return apiError(`API error (${status}): ${json.error}`);
+    }
+
+    const projects = json.data;
+    const summary = projects
+      .map((p) => `• ${p.name} (id: ${p.id}) — ${p.location ?? ""}`.trim())
+      .join("\n");
+
+    return {
+      structuredContent: { projects },
+      content: [
+        {
+          type: "text",
+          text:
+            projects.length === 0
+              ? "No projects found."
+              : `${projects.length} project(s):\n${summary}`,
+        },
+      ],
+    };
+  }
+);
+
+// ── Tool: show_projects ───────────────────────────────────────────────────────
+// Shows the project dashboard widget. Call this only when the user explicitly
+// asks to see, browse, or select a project — not as a lookup step.
+registerAppTool(
+  server,
+  "show_projects",
+  {
+    description: "Show an interactive project dashboard so the user can browse and select a project. Call this when the user says 'show projects', 'which projects', 'select a project', etc.",
+    annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    _meta: { ui: { resourceUri: WIDGET_URIS.projectDashboard } },
+  },
+  async () => {
+    let status, json;
+    try {
+      ({ status, json } = await api("/api/projects"));
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!json.success) {
+      return apiError(`API error (${status}): ${json.error}`);
+    }
+
+    const projects = json.data;
+    return {
+      structuredContent: { projects },
+      content: [],
+    };
+  }
+);
+
+// ── Tool: search_projects ─────────────────────────────────────────────────────
+// Searches projects by name or location. Use when the user mentions a project
+// by partial name and set_project returns too many or ambiguous results.
+server.registerTool(
+  "search_projects",
+  {
+    description: "Search SiteCheck projects by name or location. Use when you need to resolve an ambiguous project name to a specific project ID.",
+    inputSchema: {
+      q: z.string().describe("Search query — matched against project name and location"),
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+  },
+  async (args) => {
+    let json;
+    try {
+      ({ json } = await api(`/api/projects?q=${encodeURIComponent(args.q)}`));
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!json.success) return apiError(`API error: ${json.error}`);
+
+    const projects = json.data;
+    const summary = projects
+      .map((p) => `• ${p.name} (id: ${p.id}) — ${p.location ?? ""}`.trim())
+      .join("\n");
+
+    return {
+      structuredContent: { projects },
+      content: [
+        {
+          type: "text",
+          text: projects.length === 0
+            ? `No projects found matching "${args.q}".`
+            : `${projects.length} match(es):\n${summary}`,
+        },
+      ],
+    };
+  }
+);
+
+// ── Tool: get_deficiency ──────────────────────────────────────────────────────
+// Fetch a single deficiency by ID — used when the model needs full detail
+// before updating or when the user asks about a specific deficiency.
+server.registerTool(
+  "get_deficiency",
+  {
+    description: "Fetch full details for a single deficiency by ID (e.g. DEF-001).",
+    inputSchema: {
+      deficiency_id: z.string().describe("ID of the deficiency, e.g. DEF-001"),
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+  },
+  async (args) => {
+    let json;
+    try {
+      ({ json } = await api(`/api/deficiencies/${encodeURIComponent(args.deficiency_id)}`));
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!json.success) return apiError(`Deficiency not found: ${args.deficiency_id}`);
+
+    return {
+      structuredContent: { deficiency: json.data },
+      content: [
+        {
+          type: "text",
+          text: `${json.data.id}: ${json.data.title} — ${json.data.severity} / ${json.data.status}`,
+        },
+      ],
+    };
+  }
+);
+
+// ── Tool: log_deficiency ──────────────────────────────────────────────────────
+// Does NOT write to the DB. It returns pre-fill data for the deficiency form
+// widget. The widget calls POST /api/deficiencies on form submit.
+//
+// Design rationale: the PRD flow is "pre-filled form → user reviews → submits".
+// Giving the widget the final say on submission means the user sees and approves
+// the data before anything is written. The widget receives apiBase in
+// structuredContent so it never hardcodes the server URL.
+registerAppTool(
+  server,
+  "log_deficiency",
+  {
+    description: "Extract deficiency details from the user's description and show a pre-filled form for review before saving. Call this when the user describes a site issue or deficiency.",
+    inputSchema: {
+      project_id: z.string().describe("ID of the active project"),
+      title: z.string().describe("Short description of the deficiency, extracted from user's words"),
+      description: z.string().optional().describe("Detailed description of the deficiency"),
+      category: z
+        .enum(["Structural", "Mechanical", "Electrical", "Plumbing", "Finish", "Safety", "Other"])
+        .optional()
+        .describe("Category inferred from context — omit if unclear"),
+      location: z
+        .string()
+        .optional()
+        .describe("Grid reference or area, e.g. 'Grid B4, East Foundation Wall'"),
+      trade: z
+        .string()
+        .optional()
+        .describe("Responsible trade inferred from context, e.g. 'Concrete', 'Electrical'"),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+    _meta: { ui: { resourceUri: WIDGET_URIS.deficiencyForm } },
+  },
+  async (args) => {
+    // Verify the project exists before showing the form. Failing fast here is
+    // better than letting the widget's submit fail with a confusing 404.
+    let projectJson;
+    try {
+      const { json } = await api("/api/projects");
+      projectJson = json;
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!projectJson.success) {
+      return apiError(`API error fetching projects: ${projectJson.error}`);
+    }
+
+    const project = projectJson.data.find((p) => p.id === args.project_id);
+    if (!project) {
+      return apiError(
+        `Project not found: ${args.project_id}. Call set_project to get valid project IDs.`
+      );
+    }
+
+    return {
+      structuredContent: {
+        // Pre-fill data for the form widget
+        prefill: {
+          project_id: args.project_id,
+          title: args.title,
+          description: args.description ?? "",
+          category: args.category ?? "",
+          location: args.location ?? "",
+          trade: args.trade ?? "",
+        },
+        // Passed to the widget so it knows where to submit — never hardcoded
+        apiBase: API_BASE,
+        // Enum values for dropdowns — widget doesn't need to know the server schema
+        categories: CATEGORIES,
+        severities: SEVERITIES,
+        // Project name for display in the widget header
+        projectName: project.name,
+      },
+      content: [],
+    };
+  }
+);
+
+// ── Tool: get_deficiency_list ─────────────────────────────────────────────────
+// Passes filters straight to GET /api/deficiencies — no logic here.
+// The REST API handles filtering, pagination, and enum validation.
+registerAppTool(
+  server,
+  "get_deficiency_list",
+  {
+    description: "List deficiencies for the active project. Optionally filter by severity, status, or trade. Shows results in a table widget.",
+    inputSchema: {
+      project_id: z.string().describe("ID of the active project"),
+      severity: z
+        .enum(["Critical", "Major", "Minor", "Observation"])
+        .optional()
+        .describe("Filter by severity level"),
+      status: z
+        .enum(["Open", "In Progress", "Resolved", "Closed"])
+        .optional()
+        .describe("Filter by status"),
+      trade: z
+        .string()
+        .optional()
+        .describe("Filter by responsible trade (case-insensitive)"),
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    _meta: { ui: { resourceUri: WIDGET_URIS.deficiencyTable } },
+  },
+  async (args) => {
+    const params = new URLSearchParams({ project_id: args.project_id });
+    if (args.severity) params.set("severity", args.severity);
+    if (args.status)   params.set("status",   args.status);
+    if (args.trade)    params.set("trade",     args.trade);
+
+    let json;
+    try {
+      ({ json } = await api(`/api/deficiencies?${params}`));
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!json.success) return apiError(`API error: ${json.error}`);
+
+    const { items, total } = json.data;
+    const active = [
+      args.severity && `severity=${args.severity}`,
+      args.status   && `status=${args.status}`,
+      args.trade    && `trade=${args.trade}`,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+    return {
+      structuredContent: {
+        items,
+        total,
+        filters: { severity: args.severity, status: args.status, trade: args.trade },
+      },
+      content: [],
+    };
+  }
+);
+
+// ── Tool: set_severity ────────────────────────────────────────────────────────
+// Fetches the current deficiency, then shows a severity picker widget.
+// The widget calls PATCH /api/deficiencies/:id on selection — the tool itself
+// does not mutate anything.
+registerAppTool(
+  server,
+  "set_severity",
+  {
+    description: "Show a severity picker for a deficiency so the user can confirm or change it. Call this after log_deficiency or when the user mentions severity.",
+    inputSchema: {
+      deficiency_id: z
+        .string()
+        .describe("ID of the deficiency to update, e.g. DEF-001"),
+      severity: z
+        .enum(["Critical", "Major", "Minor", "Observation"])
+        .optional()
+        .describe("Pre-select this severity if already inferred from context — omit if unknown"),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+    _meta: { ui: { resourceUri: WIDGET_URIS.severityPicker } },
+  },
+  async (args) => {
+    let json;
+    try {
+      ({ json } = await api(`/api/deficiencies/${encodeURIComponent(args.deficiency_id)}`));
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!json.success) {
+      return apiError(
+        `Deficiency not found: ${args.deficiency_id}. Use get_deficiency_list to find valid IDs.`
+      );
+    }
+
+    const deficiency = json.data;
+    return {
+      structuredContent: {
+        deficiency_id:    deficiency.id,
+        deficiencyTitle:  deficiency.title,
+        currentSeverity:  deficiency.severity,
+        // AI's guess (or current if not provided) — widget pre-selects this
+        selectedSeverity: args.severity ?? deficiency.severity,
+        severities:       SEVERITIES,
+        apiBase:          API_BASE,
+      },
+      content: [],
+    };
+  }
+);
+
+// ── Tool: update_status ───────────────────────────────────────────────────────
+// Directly patches the status — no widget. The AI always has a specific target
+// status from the user ("mark it resolved", "close DEF-003"), so a picker adds
+// no value here. Returns the updated record as structured content for confirmation.
+server.registerTool(
+  "update_status",
+  {
+    description: `Update the status of a deficiency. Valid values: ${STATUSES.join(", ")}.`,
+    inputSchema: {
+      deficiency_id: z
+        .string()
+        .describe("ID of the deficiency to update, e.g. DEF-001"),
+      status: z
+        .enum(["Open", "In Progress", "Resolved", "Closed"])
+        .describe("New status to set"),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+  },
+  async (args) => {
+    let json;
+    try {
+      ({ json } = await api(
+        `/api/deficiencies/${encodeURIComponent(args.deficiency_id)}`,
+        { method: "PATCH", body: JSON.stringify({ status: args.status }) }
+      ));
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!json.success) return apiError(`Update failed: ${json.error}`);
+
+    const deficiency = json.data;
+    return {
+      structuredContent: { deficiency },
+      content: [
+        {
+          type: "text",
+          text: `${deficiency.id} status updated to "${deficiency.status}".`,
+        },
+      ],
+    };
+  }
+);
+
+// ── Tool: upload_photo ────────────────────────────────────────────────────────
+// MCP cannot carry binary data — the actual multipart POST happens inside the
+// widget. This tool only confirms the deficiency exists and hands the widget
+// everything it needs to upload: deficiency_id, apiBase, and the endpoint path.
+registerAppTool(
+  server,
+  "upload_photo",
+  {
+    description: "Show a photo upload widget so the user can attach an image to a deficiency. Call this after log_deficiency when the user has a photo to attach.",
+    inputSchema: {
+      deficiency_id: z
+        .string()
+        .describe("ID of the deficiency to attach the photo to, e.g. DEF-001"),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+    _meta: { ui: { resourceUri: WIDGET_URIS.photoUpload } },
+  },
+  async (args) => {
+    let json;
+    try {
+      ({ json } = await api(`/api/deficiencies/${encodeURIComponent(args.deficiency_id)}`));
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!json.success) {
+      return apiError(
+        `Deficiency not found: ${args.deficiency_id}. Use get_deficiency_list to find valid IDs.`
+      );
+    }
+
+    const deficiency = json.data;
+    const existingCount = JSON.parse(deficiency.photo_paths ?? "[]").length;
+
+    return {
+      structuredContent: {
+        deficiency_id:   deficiency.id,
+        deficiencyTitle: deficiency.title,
+        existingCount,
+        apiBase: API_BASE,
+      },
+      content: [],
+    };
+  }
+);
+
+// ── Tool: get_summary_stats ───────────────────────────────────────────────────
+// Pure read — calls /api/deficiencies/stats and passes the result to a
+// dashboard widget. No mutation, no side effects.
+registerAppTool(
+  server,
+  "get_summary_stats",
+  {
+    description: "Show a summary dashboard of deficiency counts by severity and status for the active project.",
+    inputSchema: {
+      project_id: z.string().describe("ID of the active project"),
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    _meta: { ui: { resourceUri: WIDGET_URIS.statsDashboard } },
+  },
+  async (args) => {
+    let json;
+    try {
+      ({ json } = await api(`/api/deficiencies/stats?project_id=${encodeURIComponent(args.project_id)}`));
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!json.success) return apiError(`API error: ${json.error}`);
+
+    const { total, by_severity, by_status } = json.data;
+
+    // Build a plain-text summary for the content field
+    const sevLines = Object.entries(by_severity)
+      .filter(([, n]) => n > 0)
+      .map(([s, n]) => `${s}: ${n}`)
+      .join(", ");
+
+    return {
+      structuredContent: { total, by_severity, by_status },
+      content: [],
+    };
+  }
+);
+
+// ── Tool: generate_report ─────────────────────────────────────────────────────
+// Calls POST /api/reports/generate synchronously, then passes the download URL
+// to the report-download widget. The API writes the PDF to public/reports/ and
+// returns a relative path; the widget builds the full URL using apiBase.
+registerAppTool(
+  server,
+  "generate_report",
+  {
+    description: "Generate a PDF inspection report for the active project and provide a download link.",
+    inputSchema: {
+      project_id: z.string().describe("ID of the project to generate the report for"),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+    _meta: { ui: { resourceUri: WIDGET_URIS.reportDownload } },
+  },
+  async (args) => {
+    let json;
+    try {
+      ({ json } = await api("/api/reports/generate", {
+        method: "POST",
+        body: JSON.stringify({ project_id: args.project_id }),
+      }));
+    } catch (e) {
+      return apiError(`Could not reach SiteCheck API: ${e.message}`);
+    }
+
+    if (!json.success) return apiError(`Report generation failed: ${json.error}`);
+
+    const { download_url, deficiency_count } = json.data;
+
+    return {
+      structuredContent: {
+        download_url,
+        // Widget builds the full clickable URL: apiBase + download_url
+        apiBase: API_BASE,
+        deficiency_count,
+      },
+      content: [],
+    };
+  }
+);
+
+// ── Widget resources ──────────────────────────────────────────────────────────
+widgetResource("project-dashboard-widget",  WIDGET_URIS.projectDashboard, "project-dashboard.html");
+widgetResource("deficiency-form-widget",    WIDGET_URIS.deficiencyForm,   "deficiency-form.html");
+widgetResource("deficiency-table-widget",   WIDGET_URIS.deficiencyTable,  "deficiency-table.html");
+widgetResource("severity-picker-widget",    WIDGET_URIS.severityPicker,   "severity-picker.html");
+widgetResource("photo-upload-widget",       WIDGET_URIS.photoUpload,      "photo-upload.html");
+widgetResource("stats-dashboard-widget",    WIDGET_URIS.statsDashboard,   "stats-dashboard.html");
+widgetResource("report-download-widget",    WIDGET_URIS.reportDownload,   "report-download.html");
+
+// ── Stateless Streamable HTTP transport ───────────────────────────────────────
+// A new transport is created per request. This is correct for stateless mode.
+// The McpServer instance (and its tool registrations) are shared across requests.
+// NOTE: under concurrent load this can race on server._transport — fine for demo,
+// not for production.
+
+// ── Body readers ──────────────────────────────────────────────────────────────
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    req.on("data", (chunk) => (raw += chunk));
+    req.on("end", () => {
+      try {
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch {
+        resolve({});
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function readRawBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    req.on("data", (chunk) => (raw += chunk));
+    req.on("end", () => resolve(raw));
+    req.on("error", reject);
+  });
+}
+
+// ── OAuth helpers ─────────────────────────────────────────────────────────────
+// ChatGPT requires OAuth on all MCP servers, including local dev. These
+// endpoints implement the minimum OAuth 2.0 Authorization Code flow (RFC 6749 +
+// RFC 8414 discovery) with auto-approval — every authorization succeeds
+// immediately and returns a fixed dev token. No real authentication.
+function getBaseUrl(req) {
+  // ngrok sets x-forwarded-proto / x-forwarded-host; use those when present
+  const proto = req.headers["x-forwarded-proto"] ?? "http";
+  const host  = req.headers["x-forwarded-host"] ?? req.headers["host"];
+  return `${proto}://${host}`;
+}
+
+function json(res, status, body) {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+  });
+  res.end(JSON.stringify(body));
+}
+
+// ── HTTP server ───────────────────────────────────────────────────────────────
+const httpServer = http.createServer(async (req, res) => {
+  // ── CORS preflight ──────────────────────────────────────────────────────────
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, {
+      "Access-Control-Allow-Origin":  "*",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, Mcp-Session-Id",
+    });
+    res.end();
+    return;
+  }
+
+  // ── Health check ────────────────────────────────────────────────────────────
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("ok\n");
+    return;
+  }
+
+  // ── OAuth discovery (RFC 8414) ──────────────────────────────────────────────
+  // ChatGPT fetches this first to learn where to send the user for auth.
+  if (req.method === "GET" && req.url === "/.well-known/oauth-authorization-server") {
+    const base = getBaseUrl(req);
+    json(res, 200, {
+      issuer:                 base,
+      authorization_endpoint: `${base}/authorize`,
+      token_endpoint:         `${base}/token`,
+      registration_endpoint:  `${base}/register`,
+      response_types_supported:              ["code"],
+      grant_types_supported:                 ["authorization_code"],
+      code_challenge_methods_supported:      ["S256"],
+      token_endpoint_auth_methods_supported: ["none"],
+      scopes_supported:                      ["mcp"],
+    });
+    return;
+  }
+
+  // ── Dynamic client registration (RFC 7591) ──────────────────────────────────
+  // ChatGPT registers itself as an OAuth client before starting the auth flow.
+  if (req.method === "POST" && req.url === "/register") {
+    const raw = await readRawBody(req);
+    let body = {};
+    try { body = JSON.parse(raw); } catch {}
+    json(res, 201, {
+      client_id:             `chatgpt-${Date.now()}`,
+      client_id_issued_at:   Math.floor(Date.now() / 1000),
+      token_endpoint_auth_method: "none",
+      ...body,
+    });
+    return;
+  }
+
+  // ── Authorization endpoint ──────────────────────────────────────────────────
+  // ChatGPT redirects the user here. We auto-approve and redirect straight back
+  // with an auth code — no login UI needed for dev.
+  if (req.method === "GET" && req.url?.startsWith("/authorize")) {
+    const url         = new URL(req.url, getBaseUrl(req));
+    const redirectUri = url.searchParams.get("redirect_uri");
+    const state       = url.searchParams.get("state");
+
+    if (!redirectUri) {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end("redirect_uri is required\n");
+      return;
+    }
+
+    const code     = `dev-code-${Date.now()}`;
+    const redirect = new URL(redirectUri);
+    redirect.searchParams.set("code", code);
+    if (state) redirect.searchParams.set("state", state);
+
+    res.writeHead(302, { Location: redirect.toString() });
+    res.end();
+    return;
+  }
+
+  // ── Token endpoint ──────────────────────────────────────────────────────────
+  // ChatGPT exchanges the auth code for a Bearer token. We accept any code and
+  // return a fixed dev token. The token is validated nowhere — this is dev only.
+  if (req.method === "POST" && req.url === "/token") {
+    json(res, 200, {
+      access_token: "dev-access-token",
+      token_type:   "Bearer",
+      expires_in:   86400,
+      scope:        "mcp",
+    });
+    return;
+  }
+
+  // ── MCP endpoint ────────────────────────────────────────────────────────────
+  if (req.url === "/mcp") {
+    const body = await readBody(req);
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined, // stateless
+    });
+    res.on("close", () => transport.close());
+    await server.connect(transport);
+    await transport.handleRequest(req, res, body);
+    return;
+  }
+
+  // ── Widget dev server ────────────────────────────────────────────────────────
+  // Serves widget HTML files at /widgets/<filename> so you can open them directly
+  // in a browser with URL params for dev testing, without going through ChatGPT.
+  // e.g. http://localhost:8787/widgets/severity-picker.html?deficiency_id=DEF-001
+  if (req.method === "GET" && req.url?.startsWith("/widgets/")) {
+    const filename = path.basename(req.url.split("?")[0]);
+    const filePath = path.join(__dirname, "widgets", filename);
+    if (!filename.endsWith(".html") || !fs.existsSync(filePath)) {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Widget not found\n");
+      return;
+    }
+    const html = fs.readFileSync(filePath, "utf-8");
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(html);
+    return;
+  }
+
+  res.writeHead(404);
+  res.end("Not found\n");
+});
+
+httpServer.listen(PORT, () => {
+  console.log(`✅ SiteCheck MCP server running`);
+  console.log(`   MCP endpoint : http://localhost:${PORT}/mcp`);
+  console.log(`   OAuth disco  : http://localhost:${PORT}/.well-known/oauth-authorization-server`);
+  console.log(`   Health check : http://localhost:${PORT}/health`);
+  console.log(`   REST API base: ${API_BASE}`);
+  console.log();
+  console.log(`   For ChatGPT: ngrok http ${PORT}  →  register <ngrok-url>/mcp`);
+});

--- a/mcp/widgets/deficiency-form.html
+++ b/mcp/widgets/deficiency-form.html
@@ -1,0 +1,426 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Log Deficiency — SiteCheck</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #1e1e1e;
+      --surface: #2a2a2a;
+      --border: #3a3a3a;
+      --text: #e8e8e8;
+      --text-muted: #888;
+      --accent: #4a9eff;
+      --accent-hover: #3a8eef;
+      --danger: #ff4d4d;
+      --radius: 8px;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f5f5f5;
+        --surface: #ffffff;
+        --border: #d0d0d0;
+        --text: #111;
+        --text-muted: #666;
+      }
+    }
+
+    body {
+      font-family: var(--font);
+      font-size: 14px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 16px;
+      min-height: 100vh;
+    }
+
+    h2 {
+      font-size: 15px;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+
+    .subtitle {
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-bottom: 16px;
+    }
+
+    .form-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+    }
+
+    .field { display: flex; flex-direction: column; gap: 4px; }
+    .field.full { grid-column: 1 / -1; }
+
+    label {
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    label .required { color: var(--danger); margin-left: 2px; }
+
+    input, select, textarea {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      color: var(--text);
+      font-family: var(--font);
+      font-size: 14px;
+      padding: 8px 10px;
+      width: 100%;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+
+    input:focus, select:focus, textarea:focus {
+      border-color: var(--accent);
+    }
+
+    textarea { resize: vertical; min-height: 72px; }
+
+    /* Severity buttons */
+    .severity-group { display: flex; gap: 8px; flex-wrap: wrap; }
+
+    .severity-btn {
+      flex: 1;
+      min-width: 80px;
+      padding: 7px 10px;
+      border-radius: var(--radius);
+      border: 2px solid transparent;
+      cursor: pointer;
+      font-size: 12px;
+      font-weight: 600;
+      text-align: center;
+      background: var(--surface);
+      color: var(--text-muted);
+      transition: all 0.15s;
+    }
+
+    .severity-btn[data-value="Critical"]    { border-color: #ff4d4d44; }
+    .severity-btn[data-value="Major"]       { border-color: #ff944444; }
+    .severity-btn[data-value="Minor"]       { border-color: #ffd04444; }
+    .severity-btn[data-value="Observation"] { border-color: #4a9eff44; }
+
+    .severity-btn.selected[data-value="Critical"]    { background: #ff4d4d22; border-color: #ff4d4d; color: #ff4d4d; }
+    .severity-btn.selected[data-value="Major"]       { background: #ff944422; border-color: #ff9444; color: #ff9444; }
+    .severity-btn.selected[data-value="Minor"]       { background: #ffd04422; border-color: #ffd044; color: #caa800; }
+    .severity-btn.selected[data-value="Observation"] { background: #4a9eff22; border-color: #4a9eff; color: #4a9eff; }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      justify-content: flex-end;
+    }
+
+    button {
+      padding: 8px 16px;
+      border-radius: var(--radius);
+      border: none;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 500;
+      font-family: var(--font);
+      transition: background 0.15s, opacity 0.15s;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+    }
+    .btn-primary:hover { background: var(--accent-hover); }
+    .btn-primary:disabled { opacity: 0.5; cursor: default; }
+
+    .btn-secondary {
+      background: var(--surface);
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+    .btn-secondary:hover { border-color: var(--text-muted); }
+
+    .status-bar {
+      margin-top: 12px;
+      padding: 8px 12px;
+      border-radius: var(--radius);
+      font-size: 13px;
+      display: none;
+    }
+    .status-bar.error   { background: #ff4d4d22; color: #ff4d4d; display: block; }
+    .status-bar.success { background: #4caf5022; color: #4caf50; display: block; }
+  </style>
+</head>
+<body>
+
+<h2 id="header">Log Deficiency</h2>
+<p class="subtitle" id="subtitle">Review and adjust the pre-filled fields before submitting.</p>
+
+<form id="form" novalidate>
+  <div class="form-grid">
+
+    <div class="field full">
+      <label>Title <span class="required">*</span></label>
+      <input id="title" name="title" type="text" required placeholder="Short description" />
+    </div>
+
+    <div class="field full">
+      <label>Description</label>
+      <textarea id="description" name="description" placeholder="Detailed notes…"></textarea>
+    </div>
+
+    <div class="field">
+      <label>Category <span class="required">*</span></label>
+      <select id="category" name="category" required>
+        <option value="">— select —</option>
+      </select>
+    </div>
+
+    <div class="field">
+      <label>Location</label>
+      <input id="location" name="location" type="text" placeholder="e.g. Grid B4, East Wall" />
+    </div>
+
+    <div class="field">
+      <label>Trade</label>
+      <input id="trade" name="trade" type="text" placeholder="e.g. Concrete, Electrical" />
+    </div>
+
+    <div class="field">
+      <!-- hidden — carries project_id to submit -->
+      <input id="project_id" name="project_id" type="hidden" />
+    </div>
+
+    <div class="field full">
+      <label>Severity <span class="required">*</span></label>
+      <div class="severity-group" id="severity-group">
+        <!-- populated by JS -->
+      </div>
+    </div>
+
+  </div><!-- /.form-grid -->
+
+  <div class="actions">
+    <button type="button" class="btn-secondary" id="cancel-btn">Cancel</button>
+    <button type="submit" class="btn-primary" id="submit-btn">Log Deficiency</button>
+  </div>
+
+  <div class="status-bar" id="status-bar"></div>
+</form>
+
+<script>
+// ── State ─────────────────────────────────────────────────────────────────────
+let apiBase = "http://localhost:3000"; // overridden by init data
+let selectedSeverity = "";
+
+// ── MCP Apps UI Bridge ────────────────────────────────────────────────────────
+// Receives structured content from ChatGPT via postMessage, sends actions back.
+//
+// INCOMING (ChatGPT → widget):
+//   { type: "mcp:data", payload: { structuredContent: { ... } } }
+//   { type: "data",     data: { ... } }          ← alternative format
+//
+// OUTGOING (widget → ChatGPT):
+//   { type: "mcp:result", result: { ... } }
+//   { type: "mcp:cancel" }
+//
+// ⚠️ AMBIGUITY: The exact message format for the OpenAI Apps SDK bridge is not
+// fully documented. The incoming/outgoing types above are based on the PRD spec
+// and publicly available MCP information. Validate against the live SDK and
+// adjust the type strings if the widget doesn't receive data or ChatGPT doesn't
+// receive the result.
+
+function postToParent(payload) {
+  window.parent.postMessage(payload, "*");
+}
+
+function sendResult(data) {
+  postToParent({ type: "mcp:result", result: data });
+}
+
+function sendCancel() {
+  postToParent({ type: "mcp:cancel" });
+}
+
+// ── Initialize from data ──────────────────────────────────────────────────────
+function init(data) {
+  const { prefill = {}, apiBase: base, categories = [], severities = [], projectName } = data;
+
+  if (base) apiBase = base;
+
+  // Header
+  if (projectName) {
+    document.getElementById("subtitle").textContent =
+      `Project: ${projectName} — review and adjust before submitting.`;
+  }
+
+  // Pre-fill text fields
+  document.getElementById("title").value       = prefill.title ?? "";
+  document.getElementById("description").value = prefill.description ?? "";
+  document.getElementById("location").value    = prefill.location ?? "";
+  document.getElementById("trade").value       = prefill.trade ?? "";
+  document.getElementById("project_id").value  = prefill.project_id ?? "";
+
+  // Category dropdown
+  const catSelect = document.getElementById("category");
+  for (const cat of categories) {
+    const opt = document.createElement("option");
+    opt.value = cat;
+    opt.textContent = cat;
+    if (cat === prefill.category) opt.selected = true;
+    catSelect.appendChild(opt);
+  }
+
+  // Severity buttons
+  const group = document.getElementById("severity-group");
+  for (const sev of severities) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "severity-btn";
+    btn.dataset.value = sev;
+    btn.textContent = sev;
+    btn.addEventListener("click", () => selectSeverity(sev));
+    group.appendChild(btn);
+  }
+
+  // If no severity pre-fill, default to Observation to ensure a valid form
+  selectSeverity(prefill.severity || "Observation");
+}
+
+function selectSeverity(value) {
+  selectedSeverity = value;
+  document.querySelectorAll(".severity-btn").forEach((btn) => {
+    btn.classList.toggle("selected", btn.dataset.value === value);
+  });
+}
+
+// ── Form submission → REST API ─────────────────────────────────────────────────
+document.getElementById("form").addEventListener("submit", async (e) => {
+  e.preventDefault();
+
+  const submitBtn = document.getElementById("submit-btn");
+  const statusBar = document.getElementById("status-bar");
+  statusBar.className = "status-bar";
+  statusBar.textContent = "";
+
+  const title      = document.getElementById("title").value.trim();
+  const category   = document.getElementById("category").value;
+  const project_id = document.getElementById("project_id").value;
+
+  if (!title)       return showError("Title is required.");
+  if (!category)    return showError("Category is required.");
+  if (!selectedSeverity) return showError("Severity is required.");
+  if (!project_id)  return showError("No project selected — go back and call set_project.");
+
+  submitBtn.disabled = true;
+  submitBtn.textContent = "Saving…";
+
+  const body = {
+    project_id,
+    title,
+    description: document.getElementById("description").value.trim(),
+    category,
+    severity: selectedSeverity,
+    location: document.getElementById("location").value.trim(),
+    trade: document.getElementById("trade").value.trim(),
+  };
+
+  try {
+    const res = await fetch(`${apiBase}/api/deficiencies`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const json = await res.json();
+
+    if (!json.success) {
+      showError(`Save failed: ${json.error}`);
+      return;
+    }
+
+    // Success — notify ChatGPT and show confirmation
+    showSuccess(`Logged ${json.data.id} — ${json.data.title}`);
+    sendResult({ deficiency: json.data });
+
+  } catch (err) {
+    showError(`Network error: ${err.message}`);
+  } finally {
+    submitBtn.disabled = false;
+    submitBtn.textContent = "Log Deficiency";
+  }
+});
+
+document.getElementById("cancel-btn").addEventListener("click", () => {
+  sendCancel();
+});
+
+function showError(msg) {
+  const bar = document.getElementById("status-bar");
+  bar.className = "status-bar error";
+  bar.textContent = msg;
+}
+
+function showSuccess(msg) {
+  const bar = document.getElementById("status-bar");
+  bar.className = "status-bar success";
+  bar.textContent = msg;
+}
+
+// ── Dev mode: pre-fill from URL params ───────────────────────────────────────
+// When opening the widget directly in a browser (not inside ChatGPT), seed it
+// with URL params so you can test rendering and submission without ChatGPT.
+// Example: deficiency-form.html?project_id=abc&title=Test+crack&category=Structural
+function devModeInit() {
+  const p = new URLSearchParams(location.search);
+  if (!p.has("project_id") && !p.has("title")) return; // no dev params, skip
+
+  init({
+    prefill: {
+      project_id:  p.get("project_id") ?? "",
+      title:       p.get("title") ?? "",
+      description: p.get("description") ?? "",
+      category:    p.get("category") ?? "",
+      location:    p.get("location") ?? "",
+      trade:       p.get("trade") ?? "",
+      severity:    p.get("severity") ?? "",
+    },
+    apiBase:     p.get("apiBase") ?? "http://localhost:3000",
+    categories:  ["Structural", "Mechanical", "Electrical", "Plumbing", "Finish", "Safety", "Other"],
+    severities:  ["Critical", "Major", "Minor", "Observation"],
+    projectName: p.get("projectName") ?? "Dev Project",
+  });
+}
+
+// ── Apps SDK bridge ───────────────────────────────────────────────────────────
+function rpcSend(method, params, id) {
+  const msg = { jsonrpc: "2.0", method, params: params ?? {} };
+  if (id !== undefined) msg.id = id;
+  window.parent.postMessage(msg, "*");
+}
+rpcSend("ui/initialize", {
+  appInfo: { name: "SiteCheck", version: "1.0.0" },
+  appCapabilities: {},
+  protocolVersion: "2026-01-26",
+}, "init");
+window.addEventListener("message", (event) => {
+  if (event.source !== window.parent) return;
+  const msg = event.data;
+  if (!msg || msg.jsonrpc !== "2.0") return;
+  if (msg.id === "init") rpcSend("ui/notifications/initialized");
+  if (msg.method === "ui/notifications/tool-result") init(msg.params?.structuredContent);
+});
+
+// Dev mode runs on load; ChatGPT will send the message event after load
+devModeInit();
+</script>
+</body>
+</html>

--- a/mcp/widgets/deficiency-table.html
+++ b/mcp/widgets/deficiency-table.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Deficiencies — SiteCheck</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #1e1e1e;
+      --surface: #2a2a2a;
+      --border: #3a3a3a;
+      --text: #e8e8e8;
+      --text-muted: #888;
+      --header-bg: #252525;
+      --row-hover: #303030;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f5f5f5;
+        --surface: #fff;
+        --border: #d0d0d0;
+        --text: #111;
+        --text-muted: #666;
+        --header-bg: #f0f0f0;
+        --row-hover: #f8f8f8;
+      }
+    }
+
+    body {
+      font-family: var(--font);
+      font-size: 13px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 12px;
+    }
+
+    .toolbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 10px;
+    }
+
+    .count { font-size: 12px; color: var(--text-muted); }
+
+    .filter-pills { display: flex; gap: 6px; flex-wrap: wrap; }
+
+    .pill {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 99px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+    }
+
+    .table-wrap {
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th {
+      background: var(--header-bg);
+      padding: 8px 10px;
+      text-align: left;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--text-muted);
+      cursor: pointer;
+      user-select: none;
+      white-space: nowrap;
+      border-bottom: 1px solid var(--border);
+    }
+
+    th:hover { color: var(--text); }
+    th .sort-icon { margin-left: 4px; opacity: 0.4; }
+    th.sorted .sort-icon { opacity: 1; }
+
+    td {
+      padding: 8px 10px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: middle;
+    }
+
+    tr:last-child td { border-bottom: none; }
+    tr:hover td { background: var(--row-hover); }
+
+    .id { font-family: monospace; font-size: 12px; color: var(--text-muted); }
+    .title { max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .location { max-width: 120px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-muted); }
+
+    /* Severity badges */
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 99px;
+      font-size: 11px;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .sev-Critical    { background: #ff4d4d22; color: #ff4d4d; border: 1px solid #ff4d4d55; }
+    .sev-Major       { background: #ff944422; color: #ff9444; border: 1px solid #ff944455; }
+    .sev-Minor       { background: #ffd04422; color: #b89000; border: 1px solid #ffd04455; }
+    .sev-Observation { background: #4a9eff22; color: #4a9eff; border: 1px solid #4a9eff55; }
+
+    .sta-Open        { background: #ff4d4d22; color: #ff4d4d; border: 1px solid #ff4d4d55; }
+    .sta-In-Progress { background: #ff944422; color: #ff9444; border: 1px solid #ff944455; }
+    .sta-Resolved    { background: #4caf5022; color: #4caf50; border: 1px solid #4caf5055; }
+    .sta-Closed      { background: #88888822; color: #888;    border: 1px solid #88888855; }
+
+    .empty {
+      text-align: center;
+      padding: 32px;
+      color: var(--text-muted);
+      font-style: italic;
+    }
+  </style>
+</head>
+<body>
+
+<div class="toolbar">
+  <span class="count" id="count">Loading…</span>
+  <div class="filter-pills" id="filter-pills"></div>
+</div>
+
+<div class="table-wrap">
+  <table id="table">
+    <thead>
+      <tr>
+        <th data-col="id">ID <span class="sort-icon">↕</span></th>
+        <th data-col="title">Title <span class="sort-icon">↕</span></th>
+        <th data-col="severity">Severity <span class="sort-icon">↕</span></th>
+        <th data-col="status">Status <span class="sort-icon">↕</span></th>
+        <th data-col="location">Location <span class="sort-icon">↕</span></th>
+        <th data-col="trade">Trade <span class="sort-icon">↕</span></th>
+        <th data-col="created_at">Date <span class="sort-icon">↕</span></th>
+      </tr>
+    </thead>
+    <tbody id="tbody"></tbody>
+  </table>
+</div>
+
+<script>
+// ── State ─────────────────────────────────────────────────────────────────────
+let allItems = [];
+let sortCol = "created_at";
+let sortAsc = false;
+
+const SEVERITY_ORDER = { Critical: 0, Major: 1, Minor: 2, Observation: 3 };
+const STATUS_ORDER   = { Open: 0, "In Progress": 1, Resolved: 2, Closed: 3 };
+
+// ── Render ────────────────────────────────────────────────────────────────────
+function render() {
+  const sorted = [...allItems].sort((a, b) => {
+    let va = a[sortCol] ?? "";
+    let vb = b[sortCol] ?? "";
+
+    if (sortCol === "severity") { va = SEVERITY_ORDER[va] ?? 99; vb = SEVERITY_ORDER[vb] ?? 99; }
+    if (sortCol === "status")   { va = STATUS_ORDER[va]   ?? 99; vb = STATUS_ORDER[vb]   ?? 99; }
+
+    if (va < vb) return sortAsc ? -1 : 1;
+    if (va > vb) return sortAsc ?  1 : -1;
+    return 0;
+  });
+
+  const tbody = document.getElementById("tbody");
+  tbody.innerHTML = "";
+
+  if (sorted.length === 0) {
+    tbody.innerHTML = `<tr><td colspan="7" class="empty">No deficiencies found.</td></tr>`;
+    return;
+  }
+
+  for (const item of sorted) {
+    const date = item.created_at
+      ? new Date(item.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "2-digit" })
+      : "—";
+
+    const sevClass = `sev-${item.severity}`;
+    const staClass = `sta-${(item.status ?? "").replace(/\s+/g, "-")}`;
+
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td class="id">${esc(item.id)}</td>
+      <td class="title" title="${esc(item.title)}">${esc(item.title)}</td>
+      <td><span class="badge ${sevClass}">${esc(item.severity)}</span></td>
+      <td><span class="badge ${staClass}">${esc(item.status)}</span></td>
+      <td class="location" title="${esc(item.location ?? "")}">${esc(item.location || "—")}</td>
+      <td>${esc(item.trade || "—")}</td>
+      <td>${date}</td>
+    `;
+    tbody.appendChild(tr);
+  }
+
+  // Update header sort indicators
+  document.querySelectorAll("th").forEach((th) => {
+    th.classList.toggle("sorted", th.dataset.col === sortCol);
+    const icon = th.querySelector(".sort-icon");
+    if (icon && th.dataset.col === sortCol) {
+      icon.textContent = sortAsc ? "↑" : "↓";
+    } else if (icon) {
+      icon.textContent = "↕";
+    }
+  });
+}
+
+function esc(str) {
+  return String(str ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// ── Sort on header click ──────────────────────────────────────────────────────
+document.querySelectorAll("th[data-col]").forEach((th) => {
+  th.addEventListener("click", () => {
+    const col = th.dataset.col;
+    if (sortCol === col) {
+      sortAsc = !sortAsc;
+    } else {
+      sortCol = col;
+      sortAsc = col === "id" || col === "title";
+    }
+    render();
+  });
+});
+
+// ── Initialize from data ──────────────────────────────────────────────────────
+function init(data) {
+  allItems = data.items ?? [];
+
+  document.getElementById("count").textContent =
+    `${data.total ?? allItems.length} deficiency(ies)`;
+
+  const pillsEl = document.getElementById("filter-pills");
+  pillsEl.innerHTML = "";
+  const { severity, status, trade } = data.filters ?? {};
+  for (const [label, val] of [["Severity", severity], ["Status", status], ["Trade", trade]]) {
+    if (val) {
+      const pill = document.createElement("span");
+      pill.className = "pill";
+      pill.textContent = `${label}: ${val}`;
+      pillsEl.appendChild(pill);
+    }
+  }
+
+  render();
+}
+
+// ── Apps SDK bridge ───────────────────────────────────────────────────────────
+function rpcSend(method, params, id) {
+  const msg = { jsonrpc: "2.0", method, params: params ?? {} };
+  if (id !== undefined) msg.id = id;
+  window.parent.postMessage(msg, "*");
+}
+rpcSend("ui/initialize", {
+  appInfo: { name: "SiteCheck", version: "1.0.0" },
+  appCapabilities: {},
+  protocolVersion: "2026-01-26",
+}, "init");
+window.addEventListener("message", (event) => {
+  if (event.source !== window.parent) return;
+  const msg = event.data;
+  if (!msg || msg.jsonrpc !== "2.0") return;
+  if (msg.id === "init") rpcSend("ui/notifications/initialized");
+  if (msg.method === "ui/notifications/tool-result") init(msg.params?.structuredContent);
+});
+
+// ── Dev mode ──────────────────────────────────────────────────────────────────
+// Open with ?dev=1 to see the table with mock data
+const p = new URLSearchParams(location.search);
+if (p.has("dev")) {
+  init({
+    items: [
+      { id: "DEF-001", title: "Crack in east foundation wall", severity: "Critical", status: "Open", location: "Grid B4", trade: "Concrete", created_at: new Date().toISOString() },
+      { id: "DEF-002", title: "Exposed wiring in panel room", severity: "Major", status: "In Progress", location: "Level 2", trade: "Electrical", created_at: new Date().toISOString() },
+      { id: "DEF-003", title: "Scuffed drywall finish", severity: "Minor", status: "Resolved", location: "Unit 4B", trade: "Finish", created_at: new Date().toISOString() },
+    ],
+    total: 3,
+    filters: { severity: null, status: null, trade: null },
+  });
+}
+</script>
+</body>
+</html>

--- a/mcp/widgets/photo-upload.html
+++ b/mcp/widgets/photo-upload.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Upload Photo — SiteCheck</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #1e1e1e;
+      --surface: #2a2a2a;
+      --border: #3a3a3a;
+      --border-hover: #555;
+      --text: #e8e8e8;
+      --text-muted: #888;
+      --accent: #4a9eff;
+      --radius: 10px;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f5f5f5;
+        --surface: #fff;
+        --border: #d0d0d0;
+        --border-hover: #999;
+        --text: #111;
+        --text-muted: #666;
+      }
+    }
+
+    body {
+      font-family: var(--font);
+      font-size: 14px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 16px;
+    }
+
+    h2 { font-size: 15px; font-weight: 600; margin-bottom: 4px; }
+    .subtitle { font-size: 12px; color: var(--text-muted); margin-bottom: 16px; }
+    .def-id { font-family: monospace; }
+
+    /* Drop zone */
+    .dropzone {
+      border: 2px dashed var(--border);
+      border-radius: var(--radius);
+      padding: 32px 16px;
+      text-align: center;
+      cursor: pointer;
+      transition: border-color 0.15s, background 0.15s;
+      position: relative;
+    }
+
+    .dropzone:hover,
+    .dropzone.drag-over {
+      border-color: var(--accent);
+      background: #4a9eff0a;
+    }
+
+    .dropzone input[type="file"] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+      width: 100%;
+      height: 100%;
+    }
+
+    .drop-icon { font-size: 32px; margin-bottom: 8px; }
+    .drop-label { font-size: 13px; color: var(--text-muted); }
+    .drop-hint  { font-size: 11px; color: var(--text-muted); margin-top: 4px; }
+
+    /* Preview */
+    .preview {
+      display: none;
+      border-radius: var(--radius);
+      overflow: hidden;
+      margin-bottom: 12px;
+      position: relative;
+    }
+
+    .preview img {
+      width: 100%;
+      max-height: 200px;
+      object-fit: cover;
+      display: block;
+    }
+
+    .preview .remove-btn {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      background: rgba(0,0,0,0.6);
+      color: #fff;
+      border: none;
+      border-radius: 50%;
+      width: 24px;
+      height: 24px;
+      font-size: 14px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      line-height: 1;
+    }
+
+    .file-name {
+      font-size: 12px;
+      color: var(--text-muted);
+      text-align: center;
+      margin-top: 6px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      justify-content: flex-end;
+    }
+
+    button {
+      padding: 8px 16px;
+      border-radius: 8px;
+      border: none;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 500;
+      font-family: var(--font);
+      transition: opacity 0.15s;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+    }
+    .btn-primary:disabled { opacity: 0.4; cursor: default; }
+    .btn-primary:not(:disabled):hover { background: #3a8eef; }
+
+    .btn-secondary {
+      background: var(--surface);
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+    .btn-secondary:hover { border-color: var(--text-muted); }
+
+    .status-bar {
+      margin-top: 10px;
+      padding: 8px 12px;
+      border-radius: 8px;
+      font-size: 13px;
+      display: none;
+    }
+    .status-bar.error   { background: #ff4d4d22; color: #ff4d4d; display: block; }
+    .status-bar.success { background: #4caf5022; color: #4caf50; display: block; }
+
+    .progress {
+      height: 4px;
+      background: var(--border);
+      border-radius: 2px;
+      margin-top: 10px;
+      display: none;
+      overflow: hidden;
+    }
+    .progress-bar {
+      height: 100%;
+      background: var(--accent);
+      width: 0%;
+      transition: width 0.3s;
+      border-radius: 2px;
+    }
+  </style>
+</head>
+<body>
+
+<h2>Attach Photo</h2>
+<p class="subtitle" id="subtitle">
+  Attach a photo to <span class="def-id" id="def-id">…</span>
+</p>
+
+<div class="preview" id="preview">
+  <img id="preview-img" src="" alt="Preview" />
+  <button class="remove-btn" id="remove-btn" title="Remove">✕</button>
+</div>
+<div class="file-name" id="file-name"></div>
+
+<div class="dropzone" id="dropzone">
+  <input type="file" id="file-input" accept="image/jpeg,image/png,image/webp,image/gif" />
+  <div class="drop-icon">📷</div>
+  <div class="drop-label">Drop a photo here or click to browse</div>
+  <div class="drop-hint">JPEG, PNG, WebP or GIF · max 10 MB</div>
+</div>
+
+<div class="progress" id="progress">
+  <div class="progress-bar" id="progress-bar"></div>
+</div>
+
+<div class="actions">
+  <button type="button" class="btn-secondary" id="skip-btn">Skip</button>
+  <button type="button" class="btn-primary" id="upload-btn" disabled>Upload Photo</button>
+</div>
+
+<div class="status-bar" id="status-bar"></div>
+
+<script>
+// ── State ─────────────────────────────────────────────────────────────────────
+let apiBase      = "http://localhost:3000";
+let deficiencyId = "";
+let selectedFile = null;
+
+// ── Bridge ────────────────────────────────────────────────────────────────────
+function postToParent(payload) { window.parent.postMessage(payload, "*"); }
+function sendResult(data)      { postToParent({ type: "mcp:result", result: data }); }
+function sendSkip()            { postToParent({ type: "mcp:result", result: { skipped: true } }); }
+
+// ── Initialize ────────────────────────────────────────────────────────────────
+function init(data) {
+  apiBase      = data.apiBase ?? apiBase;
+  deficiencyId = data.deficiency_id ?? "";
+
+  const label = `${deficiencyId}${data.deficiencyTitle ? ": " + data.deficiencyTitle : ""}`;
+  document.getElementById("def-id").textContent = label;
+
+  if (data.existingCount > 0) {
+    document.querySelector(".drop-hint").textContent =
+      `${data.existingCount} photo(s) already attached · JPEG, PNG, WebP or GIF · max 10 MB`;
+  }
+}
+
+// ── File selection ────────────────────────────────────────────────────────────
+function selectFile(file) {
+  if (!file) return;
+
+  const MAX = 10 * 1024 * 1024;
+  if (file.size > MAX) { showError("File too large — maximum 10 MB."); return; }
+
+  const allowed = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+  if (!allowed.includes(file.type)) { showError("Only JPEG, PNG, WebP or GIF images are accepted."); return; }
+
+  selectedFile = file;
+  document.getElementById("upload-btn").disabled = false;
+  document.getElementById("file-name").textContent = file.name;
+  document.getElementById("status-bar").className = "status-bar"; // clear errors
+
+  // Thumbnail preview
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    document.getElementById("preview-img").src = e.target.result;
+    document.getElementById("preview").style.display = "block";
+    document.getElementById("dropzone").style.display = "none";
+  };
+  reader.readAsDataURL(file);
+}
+
+document.getElementById("file-input").addEventListener("change", (e) => {
+  selectFile(e.target.files?.[0]);
+});
+
+// Drag and drop
+const dz = document.getElementById("dropzone");
+dz.addEventListener("dragover",  (e) => { e.preventDefault(); dz.classList.add("drag-over"); });
+dz.addEventListener("dragleave", ()  => dz.classList.remove("drag-over"));
+dz.addEventListener("drop", (e) => {
+  e.preventDefault();
+  dz.classList.remove("drag-over");
+  selectFile(e.dataTransfer.files?.[0]);
+});
+
+// Remove / re-pick
+document.getElementById("remove-btn").addEventListener("click", () => {
+  selectedFile = null;
+  document.getElementById("upload-btn").disabled = true;
+  document.getElementById("preview").style.display = "none";
+  document.getElementById("dropzone").style.display = "block";
+  document.getElementById("file-name").textContent = "";
+  document.getElementById("file-input").value = "";
+});
+
+// ── Upload ────────────────────────────────────────────────────────────────────
+document.getElementById("upload-btn").addEventListener("click", async () => {
+  if (!selectedFile || !deficiencyId) return;
+
+  const uploadBtn  = document.getElementById("upload-btn");
+  const progressEl = document.getElementById("progress");
+  const progressBar = document.getElementById("progress-bar");
+
+  uploadBtn.disabled = true;
+  uploadBtn.textContent = "Uploading…";
+  progressEl.style.display = "block";
+
+  // Animate progress bar (indeterminate feel)
+  let pct = 0;
+  const tick = setInterval(() => {
+    pct = Math.min(pct + 8, 85);
+    progressBar.style.width = pct + "%";
+  }, 120);
+
+  try {
+    const formData = new FormData();
+    // Field name must match what the REST API expects: "photo"
+    formData.append("photo", selectedFile);
+
+    const res = await fetch(
+      `${apiBase}/api/deficiencies/${encodeURIComponent(deficiencyId)}/photos`,
+      { method: "POST", body: formData }
+      // Do NOT set Content-Type — browser sets it with the correct boundary
+    );
+    const json = await res.json();
+
+    clearInterval(tick);
+    progressBar.style.width = "100%";
+
+    if (!json.success) {
+      showError(`Upload failed: ${json.error}`);
+      return;
+    }
+
+    showSuccess(`Photo attached: ${json.data.photo_url}`);
+    sendResult({ photo_url: json.data.photo_url, deficiency: json.data.deficiency });
+
+  } catch (err) {
+    clearInterval(tick);
+    showError(`Network error: ${err.message}`);
+  } finally {
+    uploadBtn.disabled = false;
+    uploadBtn.textContent = "Upload Photo";
+  }
+});
+
+document.getElementById("skip-btn").addEventListener("click", sendSkip);
+
+function showError(msg) {
+  const bar = document.getElementById("status-bar");
+  bar.className = "status-bar error";
+  bar.textContent = msg;
+  document.getElementById("progress").style.display = "none";
+}
+
+function showSuccess(msg) {
+  const bar = document.getElementById("status-bar");
+  bar.className = "status-bar success";
+  bar.textContent = msg;
+}
+
+// ── Apps SDK bridge ───────────────────────────────────────────────────────────
+function rpcSend(method, params, id) {
+  const msg = { jsonrpc: "2.0", method, params: params ?? {} };
+  if (id !== undefined) msg.id = id;
+  window.parent.postMessage(msg, "*");
+}
+rpcSend("ui/initialize", {
+  appInfo: { name: "SiteCheck", version: "1.0.0" },
+  appCapabilities: {},
+  protocolVersion: "2026-01-26",
+}, "init");
+window.addEventListener("message", (event) => {
+  if (event.source !== window.parent) return;
+  const msg = event.data;
+  if (!msg || msg.jsonrpc !== "2.0") return;
+  if (msg.id === "init") rpcSend("ui/notifications/initialized");
+  if (msg.method === "ui/notifications/tool-result") init(msg.params?.structuredContent);
+});
+
+// ── Dev mode ──────────────────────────────────────────────────────────────────
+const p = new URLSearchParams(location.search);
+if (p.has("deficiency_id")) {
+  init({
+    deficiency_id:   p.get("deficiency_id"),
+    deficiencyTitle: p.get("deficiencyTitle") ?? "Test deficiency",
+    existingCount:   Number(p.get("existingCount") ?? 0),
+    apiBase:         p.get("apiBase") ?? "http://localhost:3000",
+  });
+}
+</script>
+</body>
+</html>

--- a/mcp/widgets/project-dashboard.html
+++ b/mcp/widgets/project-dashboard.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Projects — SiteCheck</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #1e1e1e;
+      --surface: #2a2a2a;
+      --border: #3a3a3a;
+      --text: #e8e8e8;
+      --text-muted: #888;
+      --accent: #4a9eff;
+      --radius: 10px;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f5f5f5;
+        --surface: #fff;
+        --border: #d0d0d0;
+        --text: #111;
+        --text-muted: #666;
+      }
+    }
+
+    body {
+      font-family: var(--font);
+      font-size: 14px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 16px;
+    }
+
+    h2 { font-size: 15px; font-weight: 600; margin-bottom: 14px; }
+
+    .project-list { display: flex; flex-direction: column; gap: 8px; }
+
+    .project-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 12px 14px;
+      cursor: pointer;
+      transition: border-color 0.15s, background 0.15s;
+    }
+
+    .project-card:hover {
+      border-color: var(--accent);
+    }
+
+    .project-card.selected {
+      border-color: var(--accent);
+      background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+    }
+
+    .project-name {
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .project-location {
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-top: 3px;
+    }
+
+    .project-desc {
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-top: 4px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .empty {
+      color: var(--text-muted);
+      font-size: 13px;
+      padding: 12px 0;
+    }
+  </style>
+</head>
+<body>
+
+<h2>Projects</h2>
+<div class="project-list" id="list">
+  <div class="empty">Loading…</div>
+</div>
+
+<script>
+function render(projects) {
+  const list = document.getElementById("list");
+
+  if (!projects || projects.length === 0) {
+    list.innerHTML = '<div class="empty">No projects found.</div>';
+    return;
+  }
+
+  list.innerHTML = "";
+  for (const p of projects) {
+    const card = document.createElement("div");
+    card.className = "project-card";
+    card.dataset.id = p.id;
+    card.innerHTML = `
+      <div class="project-name">${p.name}</div>
+      ${p.location ? `<div class="project-location">${p.location}</div>` : ""}
+      ${p.description ? `<div class="project-desc">${p.description}</div>` : ""}
+    `;
+    card.addEventListener("click", () => {
+      document.querySelectorAll(".project-card").forEach(c => c.classList.remove("selected"));
+      card.classList.add("selected");
+    });
+    list.appendChild(card);
+  }
+}
+
+// ── Apps SDK bridge ───────────────────────────────────────────────────────────
+function rpcSend(method, params, id) {
+  const msg = { jsonrpc: "2.0", method, params: params ?? {} };
+  if (id !== undefined) msg.id = id;
+  window.parent.postMessage(msg, "*");
+}
+rpcSend("ui/initialize", {
+  appInfo: { name: "SiteCheck", version: "1.0.0" },
+  appCapabilities: {},
+  protocolVersion: "2026-01-26",
+}, "init");
+window.addEventListener("message", (event) => {
+  if (event.source !== window.parent) return;
+  const msg = event.data;
+  if (!msg || msg.jsonrpc !== "2.0") return;
+  if (msg.id === "init") rpcSend("ui/notifications/initialized");
+  if (msg.method === "ui/notifications/tool-result") render(msg.params?.structuredContent?.projects);
+});
+
+// Dev mode: ?dev
+if (new URLSearchParams(location.search).has("dev")) {
+  render([
+    { id: "1", name: "Maple Street Renovation", location: "88 Maple St, Boulder, CO", description: "Historic building seismic retrofit" },
+    { id: "2", name: "Harbor View Condos", location: "200 Harbor Blvd, San Diego, CA", description: "New construction high-rise" },
+    { id: "3", name: "Westside Office Park", location: "400 Commerce Dr, Austin, TX", description: "Phase 2 tenant improvements" },
+  ]);
+}
+</script>
+</body>
+</html>

--- a/mcp/widgets/report-download.html
+++ b/mcp/widgets/report-download.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Report Ready — SiteCheck</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #1e1e1e;
+      --surface: #2a2a2a;
+      --border: #3a3a3a;
+      --text: #e8e8e8;
+      --text-muted: #888;
+      --accent: #4a9eff;
+      --radius: 10px;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f5f5f5;
+        --surface: #fff;
+        --border: #d0d0d0;
+        --text: #111;
+        --text-muted: #666;
+      }
+    }
+
+    body {
+      font-family: var(--font);
+      font-size: 14px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 160px;
+      text-align: center;
+    }
+
+    .icon { font-size: 36px; margin-bottom: 10px; }
+
+    h2 { font-size: 16px; font-weight: 600; margin-bottom: 4px; }
+
+    .meta {
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-bottom: 20px;
+    }
+
+    .download-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 20px;
+      background: var(--accent);
+      color: #fff;
+      border-radius: var(--radius);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 600;
+      font-family: var(--font);
+      transition: background 0.15s;
+    }
+
+    .download-btn:hover { background: #3a8eef; }
+
+    .filename {
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-top: 10px;
+      font-family: monospace;
+      word-break: break-all;
+    }
+  </style>
+</head>
+<body>
+
+<div class="icon">📄</div>
+<h2>Report Ready</h2>
+<p class="meta" id="meta">Generating…</p>
+<a class="download-btn" id="download-btn" href="#" target="_blank" rel="noopener">
+  ⬇ Download PDF
+</a>
+<div class="filename" id="filename"></div>
+
+<script>
+function init(data) {
+  const { download_url, apiBase, deficiency_count } = data;
+
+  // Build full URL — download_url is a relative path like /reports/filename.pdf
+  const base = (apiBase ?? "http://localhost:3000").replace(/\/$/, "");
+  const fullUrl = base + download_url;
+
+  document.getElementById("meta").textContent =
+    `${deficiency_count ?? 0} deficiencie(s) included`;
+
+  const btn = document.getElementById("download-btn");
+  btn.href = fullUrl;
+
+  // Show just the filename part
+  const filename = download_url.split("/").pop() ?? download_url;
+  document.getElementById("filename").textContent = filename;
+}
+
+// ── Apps SDK bridge ───────────────────────────────────────────────────────────
+function rpcSend(method, params, id) {
+  const msg = { jsonrpc: "2.0", method, params: params ?? {} };
+  if (id !== undefined) msg.id = id;
+  window.parent.postMessage(msg, "*");
+}
+rpcSend("ui/initialize", {
+  appInfo: { name: "SiteCheck", version: "1.0.0" },
+  appCapabilities: {},
+  protocolVersion: "2026-01-26",
+}, "init");
+window.addEventListener("message", (event) => {
+  if (event.source !== window.parent) return;
+  const msg = event.data;
+  if (!msg || msg.jsonrpc !== "2.0") return;
+  if (msg.id === "init") rpcSend("ui/notifications/initialized");
+  if (msg.method === "ui/notifications/tool-result") init(msg.params?.structuredContent);
+});
+
+// ── Dev mode ──────────────────────────────────────────────────────────────────
+const p = new URLSearchParams(location.search);
+if (p.has("dev")) {
+  init({
+    download_url:      "/reports/report-dev-123456789.pdf",
+    apiBase:           "http://localhost:3000",
+    deficiency_count:  8,
+  });
+}
+</script>
+</body>
+</html>

--- a/mcp/widgets/severity-picker.html
+++ b/mcp/widgets/severity-picker.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Set Severity — SiteCheck</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #1e1e1e;
+      --surface: #2a2a2a;
+      --border: #3a3a3a;
+      --text: #e8e8e8;
+      --text-muted: #888;
+      --radius: 10px;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f5f5f5;
+        --surface: #fff;
+        --border: #d0d0d0;
+        --text: #111;
+        --text-muted: #666;
+      }
+    }
+
+    body {
+      font-family: var(--font);
+      font-size: 14px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 16px;
+    }
+
+    h2 { font-size: 15px; font-weight: 600; margin-bottom: 4px; }
+    .subtitle { font-size: 12px; color: var(--text-muted); margin-bottom: 20px; }
+    .def-id { font-family: monospace; color: var(--text-muted); }
+
+    /* Four severity tiles */
+    .picker {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+      margin-bottom: 16px;
+    }
+
+    .sev-tile {
+      padding: 14px 12px;
+      border-radius: var(--radius);
+      border: 2px solid transparent;
+      cursor: pointer;
+      text-align: center;
+      background: var(--surface);
+      transition: all 0.15s;
+    }
+
+    .sev-tile .label {
+      font-size: 13px;
+      font-weight: 700;
+      display: block;
+      margin-bottom: 4px;
+    }
+
+    .sev-tile .desc {
+      font-size: 11px;
+      color: var(--text-muted);
+      line-height: 1.4;
+    }
+
+    /* Color themes per severity */
+    .tile-Critical {
+      border-color: #ff4d4d44;
+    }
+    .tile-Critical .label { color: #ff4d4d; }
+    .tile-Critical:hover, .tile-Critical.selected {
+      background: #ff4d4d18;
+      border-color: #ff4d4d;
+    }
+
+    .tile-Major {
+      border-color: #ff944444;
+    }
+    .tile-Major .label { color: #ff9444; }
+    .tile-Major:hover, .tile-Major.selected {
+      background: #ff944418;
+      border-color: #ff9444;
+    }
+
+    .tile-Minor {
+      border-color: #ffd04444;
+    }
+    .tile-Minor .label { color: #b89000; }
+    .tile-Minor:hover, .tile-Minor.selected {
+      background: #ffd04418;
+      border-color: #ffd044;
+    }
+
+    .tile-Observation {
+      border-color: #4a9eff44;
+    }
+    .tile-Observation .label { color: #4a9eff; }
+    .tile-Observation:hover, .tile-Observation.selected {
+      background: #4a9eff18;
+      border-color: #4a9eff;
+    }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+    }
+
+    button {
+      padding: 8px 16px;
+      border-radius: 8px;
+      border: none;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 500;
+      font-family: var(--font);
+      transition: opacity 0.15s;
+    }
+
+    .btn-primary {
+      background: #4a9eff;
+      color: #fff;
+    }
+    .btn-primary:disabled { opacity: 0.4; cursor: default; }
+    .btn-primary:not(:disabled):hover { background: #3a8eef; }
+
+    .btn-secondary {
+      background: var(--surface);
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+    .btn-secondary:hover { border-color: var(--text-muted); }
+
+    .status-bar {
+      margin-top: 10px;
+      padding: 8px 12px;
+      border-radius: 8px;
+      font-size: 13px;
+      display: none;
+    }
+    .status-bar.error   { background: #ff4d4d22; color: #ff4d4d; display: block; }
+    .status-bar.success { background: #4caf5022; color: #4caf50; display: block; }
+  </style>
+</head>
+<body>
+
+<h2>Set Severity</h2>
+<p class="subtitle" id="subtitle">Select severity for <span class="def-id" id="def-id">…</span></p>
+
+<div class="picker" id="picker">
+  <!-- Tiles injected by JS so severity list comes from structured content -->
+</div>
+
+<div class="actions">
+  <button type="button" class="btn-secondary" id="cancel-btn">Cancel</button>
+  <button type="button" class="btn-primary" id="save-btn" disabled>Set Severity</button>
+</div>
+
+<div class="status-bar" id="status-bar"></div>
+
+<script>
+// ── State ─────────────────────────────────────────────────────────────────────
+let apiBase = "http://localhost:3000";
+let deficiencyId = "";
+let selectedSeverity = "";
+
+const SEVERITY_DESCS = {
+  Critical:    "Immediate action required — safety or structural risk",
+  Major:       "Significant impact — resolve before project milestone",
+  Minor:       "Low impact — address in normal workflow",
+  Observation: "Noted for record — no corrective action required",
+};
+
+// ── Bridge ────────────────────────────────────────────────────────────────────
+function postToParent(payload) { window.parent.postMessage(payload, "*"); }
+function sendResult(data)      { postToParent({ type: "mcp:result", result: data }); }
+function sendCancel()          { postToParent({ type: "mcp:cancel" }); }
+
+// ── Initialize ────────────────────────────────────────────────────────────────
+function init(data) {
+  apiBase        = data.apiBase ?? apiBase;
+  deficiencyId   = data.deficiency_id ?? "";
+  selectedSeverity = data.selectedSeverity ?? "";
+
+  document.getElementById("def-id").textContent =
+    `${deficiencyId}${data.deficiencyTitle ? ": " + data.deficiencyTitle : ""}`;
+
+  const picker = document.getElementById("picker");
+  picker.innerHTML = "";
+
+  const severities = data.severities ?? ["Critical", "Major", "Minor", "Observation"];
+  for (const sev of severities) {
+    const tile = document.createElement("div");
+    tile.className = `sev-tile tile-${sev}`;
+    tile.innerHTML = `<span class="label">${sev}</span><span class="desc">${SEVERITY_DESCS[sev] ?? ""}</span>`;
+    tile.addEventListener("click", () => selectSeverity(sev));
+    picker.appendChild(tile);
+  }
+
+  if (selectedSeverity) selectSeverity(selectedSeverity);
+}
+
+function selectSeverity(value) {
+  selectedSeverity = value;
+  document.querySelectorAll(".sev-tile").forEach((t) => {
+    t.classList.toggle("selected", t.querySelector(".label")?.textContent === value);
+  });
+  document.getElementById("save-btn").disabled = false;
+}
+
+// ── Save ──────────────────────────────────────────────────────────────────────
+document.getElementById("save-btn").addEventListener("click", async () => {
+  if (!selectedSeverity || !deficiencyId) return;
+
+  const saveBtn = document.getElementById("save-btn");
+  saveBtn.disabled = true;
+  saveBtn.textContent = "Saving…";
+
+  try {
+    const res = await fetch(`${apiBase}/api/deficiencies/${encodeURIComponent(deficiencyId)}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ severity: selectedSeverity }),
+    });
+    const json = await res.json();
+
+    if (!json.success) {
+      showError(`Save failed: ${json.error}`);
+      return;
+    }
+
+    showSuccess(`${json.data.id} severity set to ${json.data.severity}`);
+    sendResult({ deficiency: json.data });
+  } catch (err) {
+    showError(`Network error: ${err.message}`);
+  } finally {
+    saveBtn.disabled = false;
+    saveBtn.textContent = "Set Severity";
+  }
+});
+
+document.getElementById("cancel-btn").addEventListener("click", sendCancel);
+
+function showError(msg) {
+  const bar = document.getElementById("status-bar");
+  bar.className = "status-bar error";
+  bar.textContent = msg;
+}
+
+function showSuccess(msg) {
+  const bar = document.getElementById("status-bar");
+  bar.className = "status-bar success";
+  bar.textContent = msg;
+}
+
+// ── Apps SDK bridge ───────────────────────────────────────────────────────────
+function rpcSend(method, params, id) {
+  const msg = { jsonrpc: "2.0", method, params: params ?? {} };
+  if (id !== undefined) msg.id = id;
+  window.parent.postMessage(msg, "*");
+}
+rpcSend("ui/initialize", {
+  appInfo: { name: "SiteCheck", version: "1.0.0" },
+  appCapabilities: {},
+  protocolVersion: "2026-01-26",
+}, "init");
+window.addEventListener("message", (event) => {
+  if (event.source !== window.parent) return;
+  const msg = event.data;
+  if (!msg || msg.jsonrpc !== "2.0") return;
+  if (msg.id === "init") rpcSend("ui/notifications/initialized");
+  if (msg.method === "ui/notifications/tool-result") init(msg.params?.structuredContent);
+});
+
+// ── Dev mode ──────────────────────────────────────────────────────────────────
+const p = new URLSearchParams(location.search);
+if (p.has("deficiency_id")) {
+  init({
+    deficiency_id:   p.get("deficiency_id"),
+    deficiencyTitle: p.get("deficiencyTitle") ?? "Test deficiency",
+    selectedSeverity: p.get("severity") ?? "Major",
+    severities: ["Critical", "Major", "Minor", "Observation"],
+    apiBase: p.get("apiBase") ?? "http://localhost:3000",
+  });
+}
+</script>
+</body>
+</html>

--- a/mcp/widgets/stats-dashboard.html
+++ b/mcp/widgets/stats-dashboard.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Summary — SiteCheck</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #1e1e1e;
+      --surface: #2a2a2a;
+      --border: #3a3a3a;
+      --text: #e8e8e8;
+      --text-muted: #888;
+      --radius: 10px;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f5f5f5;
+        --surface: #fff;
+        --border: #d0d0d0;
+        --text: #111;
+        --text-muted: #666;
+      }
+    }
+
+    body {
+      font-family: var(--font);
+      font-size: 14px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 16px;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 16px;
+    }
+
+    h2 { font-size: 15px; font-weight: 600; }
+
+    .total {
+      font-size: 28px;
+      font-weight: 700;
+      color: var(--text);
+    }
+
+    .total-label {
+      font-size: 11px;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .section-title {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+      margin-top: 16px;
+    }
+
+    .bar-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 7px;
+    }
+
+    .bar-label {
+      width: 90px;
+      font-size: 12px;
+      font-weight: 500;
+      flex-shrink: 0;
+    }
+
+    .bar-track {
+      flex: 1;
+      height: 8px;
+      background: var(--border);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+
+    .bar-fill {
+      height: 100%;
+      border-radius: 4px;
+      transition: width 0.4s ease;
+    }
+
+    .bar-count {
+      font-size: 12px;
+      color: var(--text-muted);
+      width: 24px;
+      text-align: right;
+      flex-shrink: 0;
+    }
+
+    /* Severity colors */
+    .fill-Critical    { background: #ff4d4d; }
+    .fill-Major       { background: #ff9444; }
+    .fill-Minor       { background: #ffd044; }
+    .fill-Observation { background: #4a9eff; }
+
+    /* Status colors */
+    .fill-Open        { background: #ff4d4d; }
+    .fill-In-Progress { background: #ff9444; }
+    .fill-Resolved    { background: #4caf50; }
+    .fill-Closed      { background: #888; }
+
+    .zero { opacity: 0.35; }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <h2>Inspection Summary</h2>
+  <div>
+    <div class="total" id="total">—</div>
+    <div class="total-label">Total</div>
+  </div>
+</div>
+
+<div class="section-title">By Severity</div>
+<div id="severity-bars"></div>
+
+<div class="section-title">By Status</div>
+<div id="status-bars"></div>
+
+<script>
+const SEVERITY_ORDER = ["Critical", "Major", "Minor", "Observation"];
+const STATUS_ORDER   = ["Open", "In Progress", "Resolved", "Closed"];
+
+function renderBars(containerId, data, order) {
+  const el  = document.getElementById(containerId);
+  const max = Math.max(...Object.values(data), 1);
+  el.innerHTML = "";
+
+  for (const key of order) {
+    const count = data[key] ?? 0;
+    const pct   = Math.round((count / max) * 100);
+    const cls   = key.replace(/\s+/g, "-");
+
+    const row = document.createElement("div");
+    row.className = `bar-row${count === 0 ? " zero" : ""}`;
+    row.innerHTML = `
+      <span class="bar-label">${key}</span>
+      <div class="bar-track">
+        <div class="bar-fill fill-${cls}" style="width: ${pct}%"></div>
+      </div>
+      <span class="bar-count">${count}</span>
+    `;
+    el.appendChild(row);
+  }
+}
+
+function init(data) {
+  document.getElementById("total").textContent = data.total ?? 0;
+  renderBars("severity-bars", data.by_severity ?? {}, SEVERITY_ORDER);
+  renderBars("status-bars",   data.by_status   ?? {}, STATUS_ORDER);
+}
+
+// ── Apps SDK bridge ───────────────────────────────────────────────────────────
+function rpcSend(method, params, id) {
+  const msg = { jsonrpc: "2.0", method, params: params ?? {} };
+  if (id !== undefined) msg.id = id;
+  window.parent.postMessage(msg, "*");
+}
+// Initiate handshake — ChatGPT won't send tool-result until this completes
+rpcSend("ui/initialize", {
+  appInfo: { name: "SiteCheck", version: "1.0.0" },
+  appCapabilities: {},
+  protocolVersion: "2026-01-26",
+}, "init");
+window.addEventListener("message", (event) => {
+  if (event.source !== window.parent) return;
+  const msg = event.data;
+  if (!msg || msg.jsonrpc !== "2.0") return;
+  if (msg.id === "init") rpcSend("ui/notifications/initialized");
+  if (msg.method === "ui/notifications/tool-result") init(msg.params?.structuredContent);
+});
+
+// ── Dev mode ──────────────────────────────────────────────────────────────────
+const p = new URLSearchParams(location.search);
+if (p.has("dev")) {
+  init({
+    total: 8,
+    by_severity: { Critical: 2, Major: 3, Minor: 2, Observation: 1 },
+    by_status:   { Open: 4, "In Progress": 2, Resolved: 1, Closed: 1 },
+  });
+}
+</script>
+</body>
+</html>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Allow ChatGPT's widget sandbox and any other cross-origin callers to reach
+// the REST API. The sandbox origin looks like:
+//   https://connector_<hash>.web-sandbox.oaiusercontent.com
+export function middleware(req: NextRequest) {
+  const origin = req.headers.get("origin") ?? "*";
+
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    return new NextResponse(null, {
+      status: 204,
+      headers: corsHeaders(origin),
+    });
+  }
+
+  // Pass through and attach CORS headers to the real response
+  const res = NextResponse.next();
+  for (const [k, v] of Object.entries(corsHeaders(origin))) {
+    res.headers.set(k, v);
+  }
+  return res;
+}
+
+function corsHeaders(origin: string): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Access-Control-Allow-Credentials": "true",
+  };
+}
+
+export const config = {
+  matcher: "/api/:path*",
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,18 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ["better-sqlite3", "pdfkit"],
+  async headers() {
+    return [
+      {
+        source: "/api/:path*",
+        headers: [
+          { key: "Access-Control-Allow-Origin", value: "*" },
+          { key: "Access-Control-Allow-Methods", value: "GET, POST, PATCH, DELETE, OPTIONS" },
+          { key: "Access-Control-Allow-Headers", value: "Content-Type, Authorization" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,15 @@
       "name": "sitecheck-ai",
       "version": "0.1.0",
       "dependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.1.2",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "better-sqlite3": "^12.6.2",
         "next": "16.1.6",
         "pdfkit": "^0.17.2",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -74,6 +77,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -902,6 +906,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1470,6 +1486,111 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.1.2.tgz",
+      "integrity": "sha512-Gx4TEo3/F8yq1Ix6LdgLwMrKqfZqD7++eakZdbMUewrYtHeeJn3nKpeNhgEfO7nYRwonqWYomOAszWZWJS0IbA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "optionalDependencies": {
+        "@oven/bun-darwin-aarch64": "^1.2.21",
+        "@oven/bun-darwin-x64": "^1.2.21",
+        "@oven/bun-darwin-x64-baseline": "^1.2.21",
+        "@oven/bun-linux-aarch64": "^1.2.21",
+        "@oven/bun-linux-aarch64-musl": "^1.2.21",
+        "@oven/bun-linux-x64": "^1.2.21",
+        "@oven/bun-linux-x64-baseline": "^1.2.21",
+        "@oven/bun-linux-x64-musl": "^1.2.21",
+        "@oven/bun-linux-x64-musl-baseline": "^1.2.21",
+        "@oven/bun-windows-x64": "^1.2.21",
+        "@oven/bun-windows-x64-baseline": "^1.2.21",
+        "@rollup/rollup-darwin-arm64": "^4.53.3",
+        "@rollup/rollup-darwin-x64": "^4.53.3",
+        "@rollup/rollup-linux-arm64-gnu": "^4.53.3",
+        "@rollup/rollup-linux-x64-gnu": "^4.53.3",
+        "@rollup/rollup-win32-arm64-msvc": "^4.53.3",
+        "@rollup/rollup-win32-x64-msvc": "^4.53.3"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1674,6 +1795,227 @@
       "engines": {
         "node": ">=12.4.0"
       }
+    },
+    "node_modules/@oven/bun-darwin-aarch64": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.3.10.tgz",
+      "integrity": "sha512-PXgg5gqcS/rHwa1hF0JdM1y5TiyejVrMHoBmWY/DjtfYZoFTXie1RCFOkoG0b5diOOmUcuYarMpH7CSNTqwj+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-x64": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.3.10.tgz",
+      "integrity": "sha512-Nhssuh7GBpP5PiDSOl3+qnoIG7PJo+ec2oomDevnl9pRY6x6aD2gRt0JE+uf+A8Om2D6gjeHCxjEdrw5ZHE8mA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-x64-baseline": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.3.10.tgz",
+      "integrity": "sha512-w1gaTlqU0IJCmJ1X+PGHkdNU1n8Gemx5YKkjhkJIguvFINXEBB5U1KG82QsT65Tk4KyNMfbLTlmy4giAvUoKfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.3.10.tgz",
+      "integrity": "sha512-OUgPHfL6+PM2Q+tFZjcaycN3D7gdQdYlWnwMI31DXZKY1r4HINWk9aEz9t/rNaHg65edwNrt7dsv9TF7xK8xIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64-musl": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.3.10.tgz",
+      "integrity": "sha512-Ui5pAgM7JE9MzHokF0VglRMkbak3lTisY4Mf1AZutPACXWgKJC5aGrgnHBfkl7QS6fEeYb0juy1q4eRznRHOsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.3.10.tgz",
+      "integrity": "sha512-bzUgYj/PIZziB/ZesIP9HUyfvh6Vlf3od+TrbTTyVEuCSMKzDPQVW/yEbRp0tcHO3alwiEXwJDrWrHAguXlgiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-baseline": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.3.10.tgz",
+      "integrity": "sha512-oqvMDYpX6dGJO03HgO5bXuccEsH3qbdO3MaAiAlO4CfkBPLUXz3N0DDElg5hz0L6ktdDVKbQVE5lfe+LAUISQg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-musl": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.3.10.tgz",
+      "integrity": "sha512-poVXvOShekbexHq45b4MH/mRjQKwACAC8lHp3Tz/hEDuz0/20oncqScnmKwzhBPEpqJvydXficXfBYuSim8opw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-musl-baseline": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.3.10.tgz",
+      "integrity": "sha512-/hOZ6S1VsTX6vtbhWVL9aAnOrdpuO54mAGUWpTdMz7dFG5UBZ/VUEiK0pBkq9A1rlBk0GeD/6Y4NBFl8Ha7cRA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64/-/bun-windows-x64-1.3.10.tgz",
+      "integrity": "sha512-qaS1In3yfC/Z/IGQriVmF8GWwKuNqiw7feTSJWaQhH5IbL6ENR+4wGNPniZSJFaM/SKUO0e/YCRdoVBvgU4C1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64-baseline": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.10.tgz",
+      "integrity": "sha512-gh3UAHbUdDUG6fhLc1Csa4IGdtghue6U8oAIXWnUqawp6lwb3gOCRvp25IUnLF5vUHtgfMxuEUYV7YA2WxVutw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -2030,6 +2372,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2096,6 +2439,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2615,12 +2959,26 @@
         "win32"
       ]
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2654,6 +3012,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -2974,6 +3371,30 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3027,6 +3448,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3065,6 +3487,15 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -3088,7 +3519,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3102,7 +3532,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3210,6 +3639,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3217,11 +3668,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3310,7 +3795,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3391,6 +3875,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3423,7 +3916,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3433,6 +3925,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
@@ -3447,6 +3945,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -3544,7 +4051,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3554,7 +4060,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3592,7 +4097,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3700,6 +4204,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -3719,6 +4229,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3904,6 +4415,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4143,6 +4655,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -4150,6 +4692,68 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4202,6 +4806,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -4242,6 +4862,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -4315,6 +4956,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -4340,7 +4999,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4401,7 +5059,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4426,7 +5083,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4520,7 +5176,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4592,7 +5247,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4621,7 +5275,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4645,6 +5298,52 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -4729,6 +5428,24 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5001,6 +5718,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5157,7 +5880,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -5186,6 +5908,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.0.tgz",
+      "integrity": "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/jpeg-exif": {
@@ -5241,6 +5972,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5662,10 +6399,30 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -5690,6 +6447,31 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-response": {
@@ -5736,7 +6518,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5785,6 +6566,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/next": {
       "version": "16.1.6",
@@ -5921,7 +6711,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5931,7 +6720,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6040,6 +6828,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6136,6 +6936,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6150,7 +6959,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6162,6 +6970,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pdfkit": {
       "version": "0.17.2",
@@ -6193,6 +7011,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/png-js": {
@@ -6288,6 +7115,19 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -6306,6 +7146,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -6328,6 +7183,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -6358,6 +7237,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6367,6 +7247,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6439,6 +7320,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -6495,6 +7385,22 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/run-parallel": {
@@ -6596,6 +7502,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -6610,6 +7522,51 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -6660,6 +7617,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -6723,7 +7686,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6736,7 +7698,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6746,7 +7707,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6766,7 +7726,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6783,7 +7742,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6802,7 +7760,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6878,6 +7835,15 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7183,6 +8149,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7201,6 +8168,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7293,6 +8269,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -7377,6 +8367,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7453,6 +8444,15 @@
       "dependencies": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unrs-resolver": {
@@ -7550,11 +8550,19 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7695,10 +8703,19 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -7,15 +7,19 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "setup": "npx tsx db/setup.ts"
+    "setup": "npx tsx db/setup.ts",
+    "mcp": "node mcp/server.js"
   },
   "dependencies": {
+    "@modelcontextprotocol/ext-apps": "^1.1.2",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "better-sqlite3": "^12.6.2",
     "next": "16.1.6",
     "pdfkit": "^0.17.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/test-mcp.mjs
+++ b/test-mcp.mjs
@@ -1,0 +1,484 @@
+/**
+ * SiteCheck MCP smoke test
+ * Usage: node test-mcp.mjs
+ *
+ * Requires: MCP server running on localhost:8787  (node mcp/server.js)
+ * Requires: Next.js app running on localhost:3000 (npm run dev)
+ */
+
+const BASE = "http://localhost:8787/mcp";
+
+// ── Raw MCP JSON-RPC POST ─────────────────────────────────────────────────────
+async function mcpPost(method, params, id) {
+  const res = await fetch(BASE, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", method, params, id }),
+  });
+
+  const ct = res.headers.get("content-type") ?? "";
+  const text = await res.text();
+
+  if (!res.ok) {
+    console.error(`  HTTP ${res.status}:`, text);
+    return null;
+  }
+
+  // Streamable HTTP responds with either plain JSON or SSE
+  if (ct.includes("text/event-stream")) {
+    const messages = [];
+    for (const line of text.split("\n")) {
+      if (line.startsWith("data: ")) {
+        try {
+          messages.push(JSON.parse(line.slice(6)));
+        } catch {}
+      }
+    }
+    return messages.length === 1 ? messages[0] : messages;
+  }
+
+  return text ? JSON.parse(text) : null;
+}
+
+function pass(label) {
+  console.log(`  ✅ ${label}`);
+}
+
+function fail(label, detail) {
+  console.error(`  ❌ ${label}:`, detail);
+  process.exitCode = 1;
+}
+
+function section(title) {
+  console.log(`\n── ${title} ${"─".repeat(50 - title.length)}`);
+}
+
+// ── 1. Health check ───────────────────────────────────────────────────────────
+section("Health check");
+try {
+  const health = await fetch("http://localhost:8787/health");
+  if (health.ok) {
+    pass(`GET /health → ${health.status}`);
+  } else {
+    fail("health check", `status ${health.status}`);
+  }
+} catch (e) {
+  fail("health check — is the MCP server running?", e.message);
+  process.exit(1);
+}
+
+// ── 2. initialize ─────────────────────────────────────────────────────────────
+section("initialize");
+const init = await mcpPost(
+  "initialize",
+  {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "test-client", version: "1.0" },
+  },
+  1
+);
+if (init?.result?.protocolVersion) {
+  pass(`protocolVersion: ${init.result.protocolVersion}`);
+  pass(`serverInfo: ${JSON.stringify(init.result.serverInfo)}`);
+} else {
+  fail("initialize", JSON.stringify(init));
+}
+
+// ── 3. tools/list ─────────────────────────────────────────────────────────────
+section("tools/list");
+const toolList = await mcpPost("tools/list", {}, 2);
+const tools = toolList?.result?.tools ?? [];
+if (tools.length > 0) {
+  pass(`${tools.length} tool(s) registered`);
+  for (const t of tools) {
+    console.log(`     • ${t.name}`);
+  }
+} else {
+  fail("tools/list — expected at least 1 tool", JSON.stringify(toolList));
+}
+
+// ── 4. tools/call → set_project ───────────────────────────────────────────────
+section("tools/call → set_project");
+const callResult = await mcpPost(
+  "tools/call",
+  { name: "set_project", arguments: {} },
+  3
+);
+
+const toolResult = callResult?.result;
+if (!toolResult) {
+  fail("no result", JSON.stringify(callResult));
+} else if (toolResult.isError) {
+  fail("tool returned isError", toolResult.content?.[0]?.text);
+} else {
+  const projects = toolResult.structuredContent?.projects;
+  if (Array.isArray(projects)) {
+    pass(`structuredContent.projects is an array (${projects.length} items)`);
+    for (const p of projects) {
+      console.log(`     • ${p.name} (${p.id})`);
+    }
+  } else {
+    fail("structuredContent.projects missing or not array", JSON.stringify(toolResult.structuredContent));
+  }
+
+  const text = toolResult.content?.[0]?.text;
+  if (text) {
+    pass(`content[0].text: "${text.split("\n")[0]}"`);
+  } else {
+    fail("content[0].text missing", JSON.stringify(toolResult.content));
+  }
+}
+
+// ── 5. tools/call → log_deficiency ───────────────────────────────────────────
+// Uses the first real project ID from set_project result above
+section("tools/call → log_deficiency");
+const firstProject = toolResult?.structuredContent?.projects?.[0];
+if (!firstProject) {
+  fail("log_deficiency — no project available to test with", "");
+} else {
+  const logResult = await mcpPost(
+    "tools/call",
+    {
+      name: "log_deficiency",
+      arguments: {
+        project_id: firstProject.id,
+        title: "Test crack in east wall",
+        description: "Hairline crack observed at grid B4",
+        category: "Structural",
+        location: "Grid B4, East Foundation Wall",
+        trade: "Concrete",
+      },
+    },
+    4
+  );
+
+  const lr = logResult?.result;
+  if (!lr) {
+    fail("no result", JSON.stringify(logResult));
+  } else if (lr.isError) {
+    fail("tool returned isError", lr.content?.[0]?.text);
+  } else {
+    const prefill = lr.structuredContent?.prefill;
+    if (prefill?.title === "Test crack in east wall") {
+      pass(`structuredContent.prefill.title correct`);
+    } else {
+      fail("structuredContent.prefill.title", JSON.stringify(prefill));
+    }
+
+    if (lr.structuredContent?.apiBase) {
+      pass(`structuredContent.apiBase: ${lr.structuredContent.apiBase}`);
+    } else {
+      fail("structuredContent.apiBase missing", "");
+    }
+
+    if (Array.isArray(lr.structuredContent?.severities)) {
+      pass(`structuredContent.severities: [${lr.structuredContent.severities.join(", ")}]`);
+    } else {
+      fail("structuredContent.severities missing", "");
+    }
+
+    const meta = lr._meta;
+    if (meta?.ui?.resourceUri) {
+      pass(`_meta.ui.resourceUri: ${meta.ui.resourceUri}`);
+    } else {
+      fail("_meta.ui.resourceUri missing — widget won't render in ChatGPT", JSON.stringify(meta));
+    }
+
+    const text = lr.content?.[0]?.text;
+    if (text) {
+      pass(`content[0].text present`);
+    } else {
+      fail("content[0].text missing", "");
+    }
+  }
+}
+
+// ── 5b. tools/call → get_deficiency_list ─────────────────────────────────────
+section("tools/call → get_deficiency_list");
+if (!firstProject) {
+  fail("get_deficiency_list — no project available", "");
+} else {
+  const listResult = await mcpPost(
+    "tools/call",
+    {
+      name: "get_deficiency_list",
+      arguments: { project_id: firstProject.id },
+    },
+    41
+  );
+  const lr = listResult?.result;
+  if (!lr || lr.isError) {
+    fail("tool error", lr?.content?.[0]?.text ?? JSON.stringify(listResult));
+  } else {
+    const { items, total } = lr.structuredContent ?? {};
+    if (Array.isArray(items)) {
+      pass(`structuredContent.items: ${items.length} item(s) (total=${total})`);
+    } else {
+      fail("structuredContent.items missing", JSON.stringify(lr.structuredContent));
+    }
+    if (lr._meta?.ui?.resourceUri) {
+      pass(`_meta.ui.resourceUri: ${lr._meta.ui.resourceUri}`);
+    } else {
+      fail("_meta.ui.resourceUri missing", "");
+    }
+  }
+}
+
+// ── 5c. tools/call → set_severity ────────────────────────────────────────────
+section("tools/call → set_severity");
+// Grab a real deficiency ID from the list we just fetched
+const listForSev = await mcpPost(
+  "tools/call",
+  { name: "get_deficiency_list", arguments: { project_id: firstProject?.id ?? "" } },
+  42
+);
+const firstDef = listForSev?.result?.structuredContent?.items?.[0];
+if (!firstDef) {
+  fail("set_severity — no deficiency to test with", "");
+} else {
+  const sevResult = await mcpPost(
+    "tools/call",
+    {
+      name: "set_severity",
+      arguments: { deficiency_id: firstDef.id, severity: "Major" },
+    },
+    43
+  );
+  const sr = sevResult?.result;
+  if (!sr || sr.isError) {
+    fail("tool error", sr?.content?.[0]?.text ?? JSON.stringify(sevResult));
+  } else {
+    if (sr.structuredContent?.deficiency_id === firstDef.id) {
+      pass(`structuredContent.deficiency_id: ${sr.structuredContent.deficiency_id}`);
+    } else {
+      fail("deficiency_id mismatch", JSON.stringify(sr.structuredContent));
+    }
+    if (sr.structuredContent?.selectedSeverity === "Major") {
+      pass(`selectedSeverity pre-selected: Major`);
+    } else {
+      fail("selectedSeverity wrong", JSON.stringify(sr.structuredContent));
+    }
+    if (sr._meta?.ui?.resourceUri) {
+      pass(`_meta.ui.resourceUri: ${sr._meta.ui.resourceUri}`);
+    } else {
+      fail("_meta.ui.resourceUri missing", "");
+    }
+  }
+}
+
+// ── 5d. tools/call → update_status ───────────────────────────────────────────
+section("tools/call → update_status");
+if (!firstDef) {
+  fail("update_status — no deficiency to test with", "");
+} else {
+  const statResult = await mcpPost(
+    "tools/call",
+    {
+      name: "update_status",
+      arguments: { deficiency_id: firstDef.id, status: "In Progress" },
+    },
+    44
+  );
+  const str = statResult?.result;
+  if (!str || str.isError) {
+    fail("tool error", str?.content?.[0]?.text ?? JSON.stringify(statResult));
+  } else {
+    const def = str.structuredContent?.deficiency;
+    if (def?.status === "In Progress") {
+      pass(`status updated to "In Progress" — id: ${def.id}`);
+    } else {
+      fail("status not updated", JSON.stringify(str.structuredContent));
+    }
+    // Restore original status
+    await mcpPost("tools/call", { name: "update_status", arguments: { deficiency_id: firstDef.id, status: firstDef.status } }, 45);
+    pass(`status restored to "${firstDef.status}"`);
+  }
+}
+
+// ── 6. resources/read → deficiency-form widget ───────────────────────────────
+section("resources/read → deficiency-form widget");
+const resRead = await mcpPost(
+  "resources/read",
+  { uri: "resource://sitecheck-ai/widgets/deficiency-form" },
+  5
+);
+const widgetContents = resRead?.result?.contents;
+if (Array.isArray(widgetContents) && widgetContents[0]?.text?.includes("<!DOCTYPE html>")) {
+  pass(`Widget HTML served (${widgetContents[0].text.length} chars)`);
+} else {
+  fail("Widget HTML not returned", JSON.stringify(resRead?.result ?? resRead));
+}
+
+// ── 5e. tools/call → upload_photo ────────────────────────────────────────────
+section("tools/call → upload_photo");
+if (!firstDef) {
+  fail("upload_photo — no deficiency to test with", "");
+} else {
+  const upResult = await mcpPost(
+    "tools/call",
+    { name: "upload_photo", arguments: { deficiency_id: firstDef.id } },
+    51
+  );
+  const ur = upResult?.result;
+  if (!ur || ur.isError) {
+    fail("tool error", ur?.content?.[0]?.text ?? JSON.stringify(upResult));
+  } else {
+    if (ur.structuredContent?.deficiency_id === firstDef.id) {
+      pass(`structuredContent.deficiency_id: ${ur.structuredContent.deficiency_id}`);
+    } else {
+      fail("deficiency_id mismatch", JSON.stringify(ur.structuredContent));
+    }
+    if (ur.structuredContent?.apiBase) {
+      pass(`structuredContent.apiBase: ${ur.structuredContent.apiBase}`);
+    } else {
+      fail("structuredContent.apiBase missing", "");
+    }
+    if (ur._meta?.ui?.resourceUri) {
+      pass(`_meta.ui.resourceUri: ${ur._meta.ui.resourceUri}`);
+    } else {
+      fail("_meta.ui.resourceUri missing", "");
+    }
+  }
+}
+
+// ── 5f. tools/call → get_summary_stats ───────────────────────────────────────
+section("tools/call → get_summary_stats");
+if (!firstProject) {
+  fail("get_summary_stats — no project available", "");
+} else {
+  const statsResult = await mcpPost(
+    "tools/call",
+    { name: "get_summary_stats", arguments: { project_id: firstProject.id } },
+    52
+  );
+  const sr = statsResult?.result;
+  if (!sr || sr.isError) {
+    fail("tool error", sr?.content?.[0]?.text ?? JSON.stringify(statsResult));
+  } else {
+    const sc = sr.structuredContent ?? {};
+    if (typeof sc.total === "number") {
+      pass(`total: ${sc.total}`);
+    } else {
+      fail("total missing or not a number", JSON.stringify(sc));
+    }
+    if (sc.by_severity && typeof sc.by_severity === "object") {
+      pass(`by_severity: ${JSON.stringify(sc.by_severity)}`);
+    } else {
+      fail("by_severity missing", JSON.stringify(sc));
+    }
+    if (sc.by_status && typeof sc.by_status === "object") {
+      pass(`by_status: ${JSON.stringify(sc.by_status)}`);
+    } else {
+      fail("by_status missing", JSON.stringify(sc));
+    }
+    if (sr._meta?.ui?.resourceUri) {
+      pass(`_meta.ui.resourceUri: ${sr._meta.ui.resourceUri}`);
+    } else {
+      fail("_meta.ui.resourceUri missing", "");
+    }
+  }
+}
+
+// ── 5g. tools/call → generate_report ─────────────────────────────────────────
+section("tools/call → generate_report");
+if (!firstProject) {
+  fail("generate_report — no project available", "");
+} else {
+  const rptResult = await mcpPost(
+    "tools/call",
+    { name: "generate_report", arguments: { project_id: firstProject.id } },
+    53
+  );
+  const rr = rptResult?.result;
+  if (!rr || rr.isError) {
+    fail("tool error", rr?.content?.[0]?.text ?? JSON.stringify(rptResult));
+  } else {
+    const sc = rr.structuredContent ?? {};
+    if (sc.download_url?.startsWith("/reports/")) {
+      pass(`download_url: ${sc.download_url}`);
+    } else {
+      fail("download_url missing or wrong format", JSON.stringify(sc));
+    }
+    if (typeof sc.deficiency_count === "number") {
+      pass(`deficiency_count: ${sc.deficiency_count}`);
+    } else {
+      fail("deficiency_count missing", JSON.stringify(sc));
+    }
+    if (sc.apiBase) {
+      pass(`apiBase: ${sc.apiBase}`);
+    } else {
+      fail("apiBase missing", "");
+    }
+    if (rr._meta?.ui?.resourceUri) {
+      pass(`_meta.ui.resourceUri: ${rr._meta.ui.resourceUri}`);
+    } else {
+      fail("_meta.ui.resourceUri missing", "");
+    }
+  }
+}
+
+// ── 6b. resources/read → deficiency-table widget ─────────────────────────────
+section("resources/read → deficiency-table widget");
+const tableRes = await mcpPost("resources/read", { uri: "resource://sitecheck-ai/widgets/deficiency-table" }, 6);
+const tableContents = tableRes?.result?.contents;
+if (Array.isArray(tableContents) && tableContents[0]?.text?.includes("<!DOCTYPE html>")) {
+  pass(`Table widget HTML served (${tableContents[0].text.length} chars)`);
+} else {
+  fail("Table widget HTML not returned", JSON.stringify(tableRes?.result ?? tableRes));
+}
+
+// ── 6c. resources/read → severity-picker widget ───────────────────────────────
+section("resources/read → severity-picker widget");
+const pickerRes = await mcpPost("resources/read", { uri: "resource://sitecheck-ai/widgets/severity-picker" }, 7);
+const pickerContents = pickerRes?.result?.contents;
+if (Array.isArray(pickerContents) && pickerContents[0]?.text?.includes("<!DOCTYPE html>")) {
+  pass(`Severity picker widget HTML served (${pickerContents[0].text.length} chars)`);
+} else {
+  fail("Severity picker widget HTML not returned", JSON.stringify(pickerRes?.result ?? pickerRes));
+}
+
+// ── 6d. resources/read — remaining three widgets ──────────────────────────────
+let widgetReadId = 60;
+for (const [label, uri] of [
+  ["photo-upload widget",    "resource://sitecheck-ai/widgets/photo-upload"],
+  ["stats-dashboard widget", "resource://sitecheck-ai/widgets/stats-dashboard"],
+  ["report-download widget", "resource://sitecheck-ai/widgets/report-download"],
+]) {
+  section(`resources/read → ${label}`);
+  const r = await mcpPost("resources/read", { uri }, widgetReadId++);
+  const contents = r?.result?.contents;
+  if (Array.isArray(contents) && contents[0]?.text?.includes("<!DOCTYPE html>")) {
+    pass(`HTML served (${contents[0].text.length} chars)`);
+  } else {
+    fail("HTML not returned", JSON.stringify(r?.result ?? r));
+  }
+}
+
+// ── tools/list — verify all 8 tools registered ───────────────────────────────
+section("tools/list — final count");
+const finalList = await mcpPost("tools/list", {}, 99);
+const allTools = finalList?.result?.tools ?? [];
+const EXPECTED = ["set_project","log_deficiency","get_deficiency_list","set_severity","update_status","upload_photo","get_summary_stats","generate_report"];
+if (allTools.length === EXPECTED.length) {
+  pass(`${allTools.length}/8 tools registered`);
+  for (const t of allTools) console.log(`     • ${t.name}`);
+} else {
+  const names = allTools.map(t => t.name);
+  const missing = EXPECTED.filter(n => !names.includes(n));
+  fail(`Expected 8 tools, got ${allTools.length}. Missing: ${missing.join(", ")}`, "");
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+console.log("\n── Summary " + "─".repeat(51));
+if (process.exitCode === 1) {
+  console.log("  Some checks failed — see above.");
+} else {
+  console.log("  ✅ All 8 tools and 6 widgets passing.");
+  console.log("     Phase 2 MCP server complete.");
+  console.log("     Next: ngrok http 8787 → register in ChatGPT Dev Mode.");
+}
+console.log();

--- a/types/index.ts
+++ b/types/index.ts
@@ -50,8 +50,8 @@ export const SEVERITY_STYLES: Record<string, string> = {
 };
 
 export const STATUS_STYLES: Record<string, string> = {
-  "Open": "bg-red-100 text-red-800 border border-red-300",
-  "In Progress": "bg-amber-100 text-amber-800 border border-amber-300",
-  "Resolved": "bg-green-100 text-green-800 border border-green-300",
-  "Closed": "bg-stone-100 text-stone-600 border border-stone-300",
+  "Open": "bg-red-950 text-red-400 border border-red-800",
+  "In Progress": "bg-amber-950 text-amber-400 border border-amber-800",
+  "Resolved": "bg-green-950 text-green-400 border border-green-800",
+  "Closed": "bg-stone-800 text-stone-400 border border-stone-600",
 };


### PR DESCRIPTION
- Add MCP server (mcp/server.js) with 8 tools using registerAppTool/registerAppResource from @modelcontextprotocol/ext-apps
- Add 7 widget HTML files (project dashboard, deficiency form, deficiency list, stats, detail view, photo upload, update status) with JSON-RPC 2.0 postMessage bridge and ui/initialize handshake
- Add CORS middleware (middleware.ts) and next.config.ts headers for ChatGPT web-sandbox origins
- Add search support to GET /api/projects (?q= param)
- Add error_code field to API error responses
- Fix SQLite timestamp defaults to ISO 8601 format with strftime
- Update README with Phase 2 setup, test prompts, and MCP tools reference
- Add @modelcontextprotocol/ext-apps dependency