### PR TITLE
Serve both MCP modes from a single server via URL path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,9 @@ DATABASE_URL=./db/sitecheck.db
 # Base URL for the REST API (used by the MCP server in Phase 2)
 API_BASE_URL=http://localhost:3000
 
-# MCP server platform mode: "openai" (with widgets) or "generic" (text-only)
-MCP_PLATFORM=openai
+# MCP server port (default: 8787)
+# Both modes run simultaneously: /mcp (generic) and /mcp/openai (widgets)
+# MCP_PORT=8787
 
 # Session secret (planned — not yet used)
 # NEXTAUTH_SECRET=change-me

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,14 +118,14 @@ The MCP server uses a layered architecture with swappable platform adapters:
 [REST API]               All business logic lives here
 ```
 
-Set `MCP_PLATFORM` to choose the adapter:
+Both adapters run simultaneously on the same server — the URL path determines which one handles a request:
 
-| Value | Adapter | Response format | Widgets? |
+| Endpoint | Adapter | Response format | Widgets? |
 |---|---|---|---|
-| `openai` (default) | `adapters/openai.js` | `structuredContent` + widget HTML | Yes |
-| `generic` | `adapters/generic.js` | Plain text `content` | No |
+| `/mcp` (default) | `adapters/generic.js` | Plain text `content` | No |
+| `/mcp/openai` | `adapters/openai.js` | `structuredContent` + widget HTML | Yes |
 
-**Adding a new platform** only requires a new adapter file — no changes to core tools or existing adapters.
+**Adding a new platform** only requires a new adapter file and a new URL path — no changes to core tools or existing adapters.
 
 ### MCP Tool Definitions (`mcp/core/tools.js`)
 
@@ -240,22 +240,22 @@ npm run setup      # Initialize SQLite + seed 3 projects, 8 deficiencies
 npm run dev        # Next.js on http://localhost:3000
 ```
 
-### Phase 2 — MCP Server (OpenAI mode, default)
+### Phase 2 — MCP Server
+
+Both platform modes run simultaneously on one server:
 
 ```bash
-npm run mcp        # MCP server on http://localhost:8787 (OpenAI widgets)
-ngrok http 8787    # Expose via public HTTPS URL
+npm run mcp        # http://localhost:8787 — both endpoints active
 ```
 
-Then in ChatGPT: **Settings → Apps → Developer Mode → Add App** → paste `<ngrok-url>/mcp`
+| Endpoint | Mode | Use with |
+|---|---|---|
+| `http://localhost:8787/mcp` | Generic (text-only) | Any MCP client |
+| `http://localhost:8787/mcp/openai` | OpenAI (widgets) | ChatGPT |
 
-### Phase 2 — MCP Server (Generic mode)
+For ChatGPT: `ngrok http 8787` → **Settings → Apps → Add App** → paste `<ngrok-url>/mcp/openai`
 
-```bash
-npm run mcp:generic   # MCP server on http://localhost:8787 (text-only)
-```
-
-Connect any MCP client to `http://localhost:8787/mcp`. No ngrok or OAuth needed for local clients.
+For any other MCP client: connect to `http://localhost:8787/mcp` directly.
 
 ### Running Tests
 
@@ -274,7 +274,7 @@ See `.env.example` for the template. Copy to `.env` before running.
 |---|---|---|
 | `DATABASE_URL` | Path to SQLite file, e.g. `./db/sitecheck.db` | Yes |
 | `API_BASE_URL` | Internal base URL for REST API, e.g. `http://localhost:3000` | Phase 2 |
-| `MCP_PLATFORM` | Platform adapter: `openai` (default) or `generic` | Phase 2 |
+| `MCP_PORT` | Port for the MCP server (default: `8787`) | Phase 2 |
 | `NEXTAUTH_SECRET` | Session secret (if auth is added) | Planned |
 
 Add all new variables to `.env.example` with placeholder values. Never hardcode secrets in source.

--- a/README.md
+++ b/README.md
@@ -40,39 +40,36 @@ No Docker, no external services, no API keys required.
 
 ## Quick Start — Phase 2 (MCP Server)
 
-Requires the web app running on port 3000.
+Requires the web app running on port 3000. One server, two endpoints — both modes run simultaneously:
 
-### Option A: OpenAI mode (ChatGPT with widgets)
+| Endpoint | Mode | Response format | Use with |
+|---|---|---|---|
+| `/mcp` | Generic (default) | Plain text | Any MCP client |
+| `/mcp/openai` | OpenAI | Widgets + structuredContent | ChatGPT |
 
 ```bash
 # Terminal 1 — Next.js REST API
 npm run dev
 
-# Terminal 2 — MCP server (OpenAI mode, default)
+# Terminal 2 — MCP server (both modes on one server)
 npm run mcp     # http://localhost:8787
+```
 
+### Connect ChatGPT (OpenAI mode)
+
+```bash
 # Terminal 3 — expose MCP server publicly
 ngrok http 8787
 ```
 
-**Register in ChatGPT:**
-
 1. Go to **chatgpt.com** → profile → **Settings → Apps**
-2. Click **Add app** → paste `<ngrok-url>/mcp`
+2. Click **Add app** → paste `<ngrok-url>/mcp/openai`
 3. Complete the OAuth flow (auto-approves in dev)
 4. In a new chat, click **"+"** near the input to add SiteCheck to the conversation
 
-### Option B: Generic mode (any MCP client)
+### Connect any other MCP client (generic mode)
 
-```bash
-# Terminal 1 — Next.js REST API
-npm run dev
-
-# Terminal 2 — MCP server (generic mode, text-only)
-npm run mcp:generic   # http://localhost:8787
-```
-
-Connect any MCP client to `http://localhost:8787/mcp`. No ngrok or OAuth needed for local clients. All tools return plain text responses.
+Point your MCP client to `http://localhost:8787/mcp`. No ngrok or OAuth needed for local clients. All tools return plain text responses.
 
 ### Test prompts
 

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -5,12 +5,9 @@
  * the Next.js API routes at localhost:3000. This server only translates
  * MCP tool calls into REST API requests.
  *
- * Platform adapters control how tools are registered and what response
- * format is used:
- *   - "openai"  → ext-apps widgets + structuredContent (for ChatGPT)
- *   - "generic" → plain MCP text content (for any MCP client)
- *
- * Set MCP_PLATFORM env var to choose. Default: "openai".
+ * Both platform modes run simultaneously on the same server:
+ *   /mcp         → generic (text-only, works with any MCP client)
+ *   /mcp/openai  → OpenAI ext-apps (widgets + structuredContent for ChatGPT)
  *
  * Transport: Streamable HTTP (stateless) on port 8787
  */
@@ -22,28 +19,21 @@ import path from "node:path";
 
 import { tools } from "./core/tools.js";
 
-const PORT     = process.env.MCP_PORT ?? 8787;
-const PLATFORM = process.env.MCP_PLATFORM ?? "openai";
+const PORT = process.env.MCP_PORT ?? 8787;
 
-// ── MCP Server ────────────────────────────────────────────────────────────────
-const server = new McpServer({
-  name: "sitecheck-ai",
-  version: "1.0.0",
-});
+// ── Create one McpServer per platform adapter ─────────────────────────────────
+// Both are always available — the URL path determines which one handles a request.
 
-// ── Load platform adapter and register tools ─────────────────────────────────
-let serveWidget = null;
+const genericServer = new McpServer({ name: "sitecheck-ai", version: "1.0.0" });
+const openaiServer  = new McpServer({ name: "sitecheck-ai", version: "1.0.0" });
 
-if (PLATFORM === "openai") {
-  const adapter = await import("./adapters/openai.js");
-  adapter.register(server, tools);
-  serveWidget = adapter.serveWidget;
-} else {
-  const adapter = await import("./adapters/generic.js");
-  adapter.register(server, tools);
-}
+const genericAdapter = await import("./adapters/generic.js");
+genericAdapter.register(genericServer, tools);
 
-console.log(`   Platform     : ${PLATFORM}`);
+const openaiAdapter = await import("./adapters/openai.js");
+openaiAdapter.register(openaiServer, tools);
+
+const serveWidget = openaiAdapter.serveWidget;
 
 // ── Body readers ──────────────────────────────────────────────────────────────
 function readBody(req) {
@@ -90,6 +80,20 @@ function json(res, status, body) {
     "Access-Control-Allow-Origin": "*",
   });
   res.end(JSON.stringify(body));
+}
+
+/**
+ * Handle an MCP request by connecting the appropriate server to a fresh
+ * stateless transport and processing the request.
+ */
+async function handleMcp(server, req, res) {
+  const body = await readBody(req);
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+  res.on("close", () => transport.close());
+  await server.connect(transport);
+  await transport.handleRequest(req, res, body);
 }
 
 // ── HTTP server ───────────────────────────────────────────────────────────────
@@ -176,20 +180,22 @@ const httpServer = http.createServer(async (req, res) => {
     return;
   }
 
-  // ── MCP endpoint ────────────────────────────────────────────────────────────
-  if (req.url === "/mcp") {
-    const body = await readBody(req);
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined,
-    });
-    res.on("close", () => transport.close());
-    await server.connect(transport);
-    await transport.handleRequest(req, res, body);
+  // ── MCP endpoints ───────────────────────────────────────────────────────────
+  // /mcp/openai  → OpenAI adapter (widgets + structuredContent)
+  // /mcp         → Generic adapter (text-only, default)
+
+  if (req.url === "/mcp/openai") {
+    await handleMcp(openaiServer, req, res);
     return;
   }
 
-  // ── Widget dev server (OpenAI mode only) ────────────────────────────────────
-  if (req.method === "GET" && req.url?.startsWith("/widgets/") && serveWidget) {
+  if (req.url === "/mcp") {
+    await handleMcp(genericServer, req, res);
+    return;
+  }
+
+  // ── Widget dev server ───────────────────────────────────────────────────────
+  if (req.method === "GET" && req.url?.startsWith("/widgets/")) {
     const filename = path.basename(req.url.split("?")[0]);
     const html = serveWidget(filename);
     if (!html) {
@@ -210,15 +216,13 @@ const API_BASE = process.env.API_BASE_URL ?? "http://localhost:3000";
 
 httpServer.listen(PORT, () => {
   console.log(`\n✅ SiteCheck MCP server running`);
-  console.log(`   MCP endpoint : http://localhost:${PORT}/mcp`);
-  console.log(`   Platform     : ${PLATFORM}`);
-  console.log(`   OAuth disco  : http://localhost:${PORT}/.well-known/oauth-authorization-server`);
-  console.log(`   Health check : http://localhost:${PORT}/health`);
-  console.log(`   REST API base: ${API_BASE}`);
-  if (PLATFORM === "openai") {
-    console.log(`\n   For ChatGPT: ngrok http ${PORT}  →  register <ngrok-url>/mcp`);
-  } else {
-    console.log(`\n   Generic MCP mode — connect any MCP client to http://localhost:${PORT}/mcp`);
-  }
+  console.log(`   MCP (generic) : http://localhost:${PORT}/mcp`);
+  console.log(`   MCP (OpenAI)  : http://localhost:${PORT}/mcp/openai`);
+  console.log(`   OAuth disco   : http://localhost:${PORT}/.well-known/oauth-authorization-server`);
+  console.log(`   Health check  : http://localhost:${PORT}/health`);
+  console.log(`   Widget dev    : http://localhost:${PORT}/widgets/`);
+  console.log(`   REST API base : ${API_BASE}`);
+  console.log(`\n   For ChatGPT: ngrok http ${PORT}  →  register <ngrok-url>/mcp/openai`);
+  console.log(`   For others : connect MCP client to http://localhost:${PORT}/mcp`);
   console.log();
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "typecheck": "tsc --noEmit",
     "setup": "npx tsx db/setup.ts",
     "mcp": "node mcp/server.js",
-    "mcp:generic": "MCP_PLATFORM=generic node mcp/server.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary

- Both platform adapters now run simultaneously on one server — no restart needed to switch modes
- `/mcp` → generic (text-only, any MCP client)
- `/mcp/openai` → OpenAI ext-apps (widgets + structuredContent for ChatGPT)
- Removed `MCP_PLATFORM` env var and `mcp:generic` npm script (no longer needed)
- Updated CLAUDE.md, README.md, and .env.example

## Test plan

- [x] `npm test` — 74 tests pass
- [x] `npm run lint` — 0 errors
- [x] Verified `/mcp` returns plain text content
- [x] Verified `/mcp/openai` returns structuredContent with widget metadata
- [x] Both endpoints work simultaneously from the same running server
- [ ] Manual test with ChatGPT via `/mcp/openai`


Made with [Cursor](https://cursor.com)