### PR TITLE
Claude support, timeouts, and platform-specific tool descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,8 @@ Each tool is a plain object with platform-neutral handler logic:
 - `formatText(result)` — human-readable text for generic MCP clients
 - `formatStructured(result)` — structured payload for widget-capable platforms
 - `widget` — `{ uri, file }` if the tool has a UI widget, `null` otherwise
+- `description` — used by the OpenAI adapter (widget-oriented: minimal reply, don't restate). Required.
+- `descriptionGeneric` — optional; used by the generic adapter when present. Instructs the LLM to summarize or interpret the tool result; if absent, generic adapter uses `description`.
 
 The adapters decide which handler and formatter to use. Tool handlers must **not** contain platform-specific logic.
 
@@ -314,7 +316,7 @@ Add all new variables to `.env.example` with placeholder values. Never hardcode 
 
 ### Adding a New MCP Tool
 
-1. **Tool definition:** Add a new object to the `tools` array in `mcp/core/tools.js` with `name`, `description`, `inputSchema` (zod), `annotations`, `handler(args)`, `formatText(result)`, and optionally `widget`, `directHandler`, `formatStructured`
+1. **Tool definition:** Add a new object to the `tools` array in `mcp/core/tools.js` with `name`, `description`, `inputSchema` (zod), `annotations`, `handler(args)`, `formatText(result)`, and optionally `widget`, `directHandler`, `formatStructured`, `descriptionGeneric`. For tools with widget-specific LLM instructions (e.g. "do not restate"), add `descriptionGeneric` so generic MCP clients are instructed to summarize or interpret the tool result.
 2. **Widget (if needed):** Create `mcp/widgets/<name>.html` with `<!-- SHARED:CSS -->` and `<!-- SHARED:BRIDGE -->` placeholders, and an `init(data)` function
 3. **Set `widget`** to `{ uri: "ui://sitecheck/<name>.html", file: "<name>.html" }` — the OpenAI adapter auto-registers the resource
 4. **directHandler:** If the tool is interactive (widget does the mutation), add a `directHandler` that performs the action directly for generic mode

--- a/README.md
+++ b/README.md
@@ -71,6 +71,82 @@ ngrok http 8787
 
 Point your MCP client to `http://localhost:8787/mcp`. No ngrok or OAuth needed for local clients. All tools return plain text responses.
 
+### Connect Claude Desktop (generic and/or MCP Apps)
+
+Claude Desktop only supports **stdio** MCP servers. This app exposes **Streamable HTTP**, so you need a small proxy that speaks stdio to Claude and HTTP to this server.
+
+**Prerequisites**
+
+- App and MCP server running (`npm run dev` and `npm run mcp`)
+- [uv](https://docs.astral.sh/uv/) (install: `curl -LsSf https://astral.sh/uv/install.sh | sh`). Then `uvx mcp-proxy` works (uv fetches the Python proxy on first use). Alternatively: Python 3.10+ with `pip install mcp-proxy`.
+
+**Option A — Generic MCP (text-only)**
+
+Claude gets the same tools with plain-text responses; it will summarize and interpret the data.
+
+1. Open Claude Desktop → **Settings** → **Developer** → **Edit Config**
+2. Add a proxy entry that forwards stdio to `http://localhost:8787/mcp`:
+
+```json
+{
+  "mcpServers": {
+    "sitecheck": {
+      "command": "/Users/YOUR_USERNAME/.local/bin/uvx",
+      "args": [
+        "mcp-proxy",
+        "--transport",
+        "streamablehttp",
+        "http://localhost:8787/mcp"
+      ]
+    }
+  }
+}
+```
+
+**Important:** Use the **full path** to `uvx` (e.g. `/Users/frankreno/.local/bin/uvx`). Do not use just `uvx` — Claude Desktop does not inherit your shell PATH, so you get "Failed to spawn process: No such file or directory" if the command is not fully qualified. Replace `YOUR_USERNAME` with your macOS username, or run `which uvx` in a terminal (after `source ~/.local/bin/env`) and paste that path.
+
+3. Save, then **fully quit and restart** Claude Desktop (not just the window).
+4. Start a new chat; Claude can use SiteCheck tools and will respond with summarized text.
+
+**Option B — MCP Apps (widgets, like ChatGPT)**
+
+Claude supports the same [MCP Apps (ext-apps)](https://claude.com/docs/connectors/building/mcp-apps/getting-started) protocol as ChatGPT. Use the **OpenAI** endpoint so Claude gets widgets (dashboards, forms, tables) inline.
+
+1. In the same config, add a second server (or replace `sitecheck` with this):
+
+```json
+{
+  "mcpServers": {
+    "sitecheck-apps": {
+      "command": "/Users/YOUR_USERNAME/.local/bin/uvx",
+      "args": [
+        "mcp-proxy",
+        "--transport",
+        "streamablehttp",
+        "http://localhost:8787/mcp/openai"
+      ]
+    }
+  }
+}
+```
+
+2. Save and fully restart Claude Desktop.
+3. In a new chat, Claude may prompt to allow the App; choose **Always allow** to see widgets.
+4. Use the same kinds of prompts as in the test table below (e.g. “Show my SiteCheck projects”, “Show deficiencies for Maple Street”).
+
+You can have both entries (e.g. `sitecheck` for generic and `sitecheck-apps` for widgets) or only one. For widgets, only the `sitecheck-apps` entry is needed.
+
+**Config file locations**
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux:** `~/.config/Claude/claude_desktop_config.json`
+
+**Troubleshooting**
+
+- **"Failed to spawn process: No such file or directory"** — Use the **full path** to `uvx` (e.g. `/Users/YourName/.local/bin/uvx`), not just `uvx`.
+- **"Request timed out" / "Server disconnected without sending a response"** — The MCP server calls the REST API at `localhost:3000`. If the Next.js app is not running or is slow, tool calls can hang. **Keep `npm run dev` running** in a separate terminal. The server will give up after 25 seconds and return an error instead of hanging; if you still hit timeouts, check that http://localhost:3000 loads and that the app is not stuck.
+
 ### Test prompts
 
 | Prompt | Widget rendered |

--- a/mcp/__tests__/core/handlers.test.js
+++ b/mcp/__tests__/core/handlers.test.js
@@ -184,6 +184,12 @@ describe("Core tool handlers", () => {
 
   // ── get_deficiency_list ───────────────────────────────────────────────────
   describe("get_deficiency_list", () => {
+    it("handler errors when project_id is missing", async () => {
+      const result = await getTool("get_deficiency_list").handler({});
+      expect(result.error).toBeDefined();
+      expect(result.error).toContain("project_id is required");
+    });
+
     it("returns list with filters", async () => {
       const result = await getTool("get_deficiency_list").handler({
         project_id: "proj-001",
@@ -380,6 +386,15 @@ describe("Core tool handlers", () => {
       for (const tool of tools) {
         expect(tool.name).toBeTruthy();
         expect(tool.description).toBeTruthy();
+      }
+    });
+
+    it("descriptionGeneric when set is used by generic adapter; no tool has only descriptionGeneric", () => {
+      for (const tool of tools) {
+        if (tool.descriptionGeneric != null) {
+          expect(tool.description).toBeTruthy();
+          expect(typeof tool.descriptionGeneric).toBe("string");
+        }
       }
     });
 

--- a/mcp/adapters/generic.js
+++ b/mcp/adapters/generic.js
@@ -27,7 +27,7 @@ export function register(server, tools) {
     server.registerTool(
       tool.name,
       {
-        description: tool.description,
+        description: tool.descriptionGeneric ?? tool.description,
         ...(Object.keys(tool.inputSchema).length > 0 ? { inputSchema: tool.inputSchema } : {}),
         annotations: tool.annotations,
       },

--- a/mcp/core/api-client.js
+++ b/mcp/core/api-client.js
@@ -11,16 +11,31 @@ export const CATEGORIES = ["Structural", "Mechanical", "Electrical", "Plumbing",
 export const SEVERITIES = ["Critical", "Major", "Minor", "Observation"];
 export const STATUSES   = ["Open", "In Progress", "Resolved", "Closed"];
 
+/** Request timeout in ms so the MCP server responds before clients (e.g. Claude proxy) time out. */
+const API_TIMEOUT_MS = 25_000;
+
 /**
  * Fetch JSON from the REST API. Returns { status, json }.
- * Throws on network errors — callers should catch and surface via apiError().
+ * Throws on network errors or timeout — callers should catch and surface via apiError().
  */
 export async function api(path, options = {}) {
+  const signal = options.signal ?? AbortSignal.timeout(API_TIMEOUT_MS);
   const res = await fetch(`${API_BASE}${path}`, {
     headers: { "Content-Type": "application/json" },
     ...options,
+    signal,
   });
-  const json = await res.json();
+  let json;
+  if (typeof res.text === "function") {
+    const text = await res.text();
+    try {
+      json = text ? JSON.parse(text) : {};
+    } catch {
+      throw new Error(`API returned non-JSON (${res.status}): ${text.slice(0, 200)}`);
+    }
+  } else {
+    json = typeof res.json === "function" ? await res.json() : {};
+  }
   return { status: res.status, json };
 }
 

--- a/mcp/core/tools.js
+++ b/mcp/core/tools.js
@@ -3,12 +3,18 @@
  *
  * Each tool is a plain object with:
  *   - name, description, inputSchema (zod), annotations
+ *   - descriptionGeneric – optional; used by the generic adapter when present. Instructs the LLM
+ *                          to summarize or interpret the tool result. If absent, generic adapter uses description.
  *   - widget        – { uri, file } if the tool has a UI widget, null otherwise
  *   - handler(args) – calls the REST API; returns { data } or { error }
  *   - directHandler – optional override for non-widget platforms (e.g. log_deficiency
  *                     creates the deficiency directly instead of returning a pre-fill form)
  *   - formatText(result)       – human-readable text for generic MCP clients
  *   - formatStructured(result) – structuredContent payload for widget-capable platforms
+ *
+ * description is used by the OpenAI adapter (widget-oriented: minimal reply, don't restate).
+ * The generic adapter uses descriptionGeneric ?? description so text-only clients get guidance
+ * to summarize/interpret the returned data.
  *
  * The adapters (openai.js, generic.js) decide which handler and formatter to use.
  */
@@ -74,6 +80,8 @@ export const tools = [
     name: "show_projects",
     description:
       "Show an interactive project dashboard so the user can browse and select a project. Call this when the user says 'show projects', 'which projects', 'select a project', etc. The embedded widget fully satisfies this request — do not restate project names, locations, or descriptions in text. Reply with one short sentence at most (e.g. 'Here are your projects.').",
+    descriptionGeneric:
+      "List SiteCheck projects so the user can browse or select one. Call when the user says 'show projects', 'which projects', 'select a project', etc. The tool returns the project list; summarize or highlight the options for the user.",
     inputSchema: {},
     annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
     widget: { uri: WIDGET_URIS.projectDashboard, file: "project-dashboard.html" },
@@ -105,6 +113,8 @@ export const tools = [
     name: "search_projects",
     description:
       "Search SiteCheck projects by name or location. Use when the user asks to see or select projects matching a name (e.g. 'Maple Street'). Shows results in the project dashboard widget.",
+    descriptionGeneric:
+      "Search SiteCheck projects by name or location. Use when the user asks to see or select projects matching a name (e.g. 'Maple Street'). Results are returned as data; present or summarize them for the user.",
     inputSchema: {
       q: z.string().describe("Search query — matched against project name and location"),
     },
@@ -169,6 +179,8 @@ export const tools = [
     name: "log_deficiency",
     description:
       "Extract deficiency details from the user's description and show a pre-filled form for review before saving. Call this when the user describes a site issue or deficiency. The widget handles all input — do not narrate or list the form fields in text. After calling this tool, say nothing or at most one short sentence like 'Here's the form — review and submit when ready.'",
+    descriptionGeneric:
+      "Create a new deficiency from the user's description of a site issue. Call when the user describes something to log. The tool creates the deficiency and returns its details; confirm what was created and suggest next steps (e.g. set severity, add a photo) as appropriate.",
     inputSchema: {
       project_id: z.string().describe("ID of the active project"),
       title: z.string().describe("Short description of the deficiency, extracted from user's words"),
@@ -270,6 +282,8 @@ export const tools = [
     name: "get_deficiency_list",
     description:
       "List deficiencies for the active project. Optionally filter by severity, status, or trade. Shows results in a table widget. The widget fully satisfies this request — do not restate deficiency IDs, titles, or details in text. Reply with one short sentence at most (e.g. 'Here are the open deficiencies.').",
+    descriptionGeneric:
+      "List deficiencies for the active project. Optionally filter by severity, status, or trade. The tool returns the list; summarize it for the user (e.g. counts, highlights) and interpret as needed.",
     inputSchema: {
       project_id: z.string().describe("ID of the active project"),
       severity: z.enum(["Critical", "Major", "Minor", "Observation"]).optional().describe("Filter by severity level"),
@@ -280,6 +294,9 @@ export const tools = [
     widget: { uri: WIDGET_URIS.deficiencyTable, file: "deficiency-table.html" },
 
     handler: async (args) => {
+      if (!args.project_id || typeof args.project_id !== "string") {
+        return { error: "project_id is required. Call show_projects or set_project first to get a project ID." };
+      }
       const params = new URLSearchParams({ project_id: args.project_id });
       if (args.severity) params.set("severity", args.severity);
       if (args.status)   params.set("status",   args.status);
@@ -330,6 +347,8 @@ export const tools = [
     name: "set_severity",
     description:
       "Show a severity picker for a deficiency so the user can confirm or change it. Call this after log_deficiency or when the user mentions severity. The widget handles user input — do not list severity options or describe the picker in text. Say nothing after calling this tool; wait for the user to interact with the widget.",
+    descriptionGeneric:
+      "Set or prompt for the severity of a deficiency. Call after log_deficiency or when the user mentions severity. If severity is provided, the tool updates it; otherwise it returns current severity and options. Confirm the update or ask the user to choose a severity as appropriate.",
     inputSchema: {
       deficiency_id: z.string().describe("ID of the deficiency to update, e.g. DEF-001"),
       severity: z.enum(["Critical", "Major", "Minor", "Observation"]).optional()
@@ -446,6 +465,8 @@ export const tools = [
     name: "upload_photo",
     description:
       "Show a photo upload widget so the user can attach an image to a deficiency. Call this after log_deficiency when the user has a photo to attach. The widget handles the upload — do not describe the upload process in text. Say nothing after calling this tool; wait for the user to interact with the widget.",
+    descriptionGeneric:
+      "Attach a photo to a deficiency. In this mode photo upload is not available; the tool returns instructions for using the web app. Explain the limitation and point the user to the web app to attach photos.",
     inputSchema: {
       deficiency_id: z.string().describe("ID of the deficiency to attach the photo to, e.g. DEF-001"),
     },
@@ -513,6 +534,8 @@ export const tools = [
     name: "get_summary_stats",
     description:
       "Show a summary dashboard of deficiency counts by severity and status for the active project. The embedded widget fully satisfies this request — do not restate the counts in text. Reply with one short sentence at most (e.g. 'Here's the inspection summary.').",
+    descriptionGeneric:
+      "Get a summary of deficiency counts by severity and status for the active project. The tool returns the breakdown; summarize and interpret the stats for the user.",
     inputSchema: {
       project_id: z.string().describe("ID of the active project"),
     },
@@ -552,6 +575,8 @@ export const tools = [
     name: "generate_report",
     description:
       "Generate a PDF inspection report for the active project and provide a download link. The widget shows the download button — do not paste the URL or filename in text. Reply with one short sentence at most (e.g. 'Your report is ready.').",
+    descriptionGeneric:
+      "Generate a PDF inspection report for the active project. The tool returns a download URL and deficiency count; you may present the link and briefly describe the report.",
     inputSchema: {
       project_id: z.string().describe("ID of the project to generate the report for"),
     },

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -21,19 +21,15 @@ import { tools } from "./core/tools.js";
 
 const PORT = process.env.MCP_PORT ?? 8787;
 
-// ── Create one McpServer per platform adapter ─────────────────────────────────
-// Both are always available — the URL path determines which one handles a request.
-
-const genericServer = new McpServer({ name: "sitecheck-ai", version: "1.0.0" });
-const openaiServer  = new McpServer({ name: "sitecheck-ai", version: "1.0.0" });
+// ── Load adapters once; create one McpServer per request ───────────────────────
+// Claude (and other clients) often send tools/call and tools/list concurrently.
+// Sharing a single server would connect it to multiple transports and drop one
+// response, causing "Request timed out" / "Server disconnected". So we create
+// a fresh server per request (stateless).
 
 const genericAdapter = await import("./adapters/generic.js");
-genericAdapter.register(genericServer, tools);
-
-const openaiAdapter = await import("./adapters/openai.js");
-openaiAdapter.register(openaiServer, tools);
-
-const serveWidget = openaiAdapter.serveWidget;
+const openaiAdapter  = await import("./adapters/openai.js");
+const serveWidget    = openaiAdapter.serveWidget;
 
 // ── Body readers ──────────────────────────────────────────────────────────────
 function readBody(req) {
@@ -183,14 +179,21 @@ const httpServer = http.createServer(async (req, res) => {
   // ── MCP endpoints ───────────────────────────────────────────────────────────
   // /mcp/openai  → OpenAI adapter (widgets + structuredContent)
   // /mcp         → Generic adapter (text-only, default)
+  // Only POST is valid; GET (e.g. browser) returns 405 to avoid 502 behind proxies.
 
-  if (req.url === "/mcp/openai") {
-    await handleMcp(openaiServer, req, res);
-    return;
-  }
-
-  if (req.url === "/mcp") {
-    await handleMcp(genericServer, req, res);
+  if (req.url === "/mcp/openai" || req.url === "/mcp") {
+    if (req.method !== "POST") {
+      res.writeHead(405, { "Content-Type": "application/json", "Allow": "POST" });
+      res.end(JSON.stringify({ error: "Method Not Allowed", message: "MCP endpoint accepts POST only. Use an MCP client or proxy (e.g. uvx mcp-proxy)." }));
+      return;
+    }
+    const server = new McpServer({ name: "sitecheck-ai", version: "1.0.0" });
+    if (req.url === "/mcp/openai") {
+      openaiAdapter.register(server, tools);
+    } else {
+      genericAdapter.register(server, tools);
+    }
+    await handleMcp(server, req, res);
     return;
   }
 


### PR DESCRIPTION
## Summary
- **Platform-specific tool descriptions**: `descriptionGeneric` for generic MCP so the LLM is instructed to summarize/interpret data; OpenAI keeps minimal-reply descriptions.
- **API client**: 25s timeout so MCP responds before proxy timeouts; safe JSON parsing when API returns non-JSON; mock-friendly (res.text vs res.json).
- **get_deficiency_list**: Validate `project_id` and return a clear error if missing.
- **MCP endpoints**: Require POST, return 405 for GET to avoid 502 behind proxies.
- **Per-request McpServer**: Create one server per request so concurrent requests (e.g. tools/call + tools/list) don't share a transport and cause timeouts in Claude apps.
- **README**: Claude Desktop setup (generic + MCP Apps), full path for uvx, troubleshooting for spawn and timeout.
- **CLAUDE.md**: Document `descriptionGeneric`; tests for validation and descriptionGeneric.

Made with [Cursor](https://cursor.com)